### PR TITLE
[FEAT] 제안 물품 생성(추가) 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/product/controller/SuggestedProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/SuggestedProductController.java
@@ -1,0 +1,29 @@
+package com.barter.domain.product.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
+import com.barter.domain.product.service.SuggestedProductService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/suggested-products")
+@RequiredArgsConstructor
+public class SuggestedProductController {
+
+	private final SuggestedProductService suggestedProductService;
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public void createSuggestedProduct(@RequestBody @Valid CreateSuggestedProductReqDto request) {
+		// 현재 인증/인가 파트의 구현이 완료되지 않아 요청 회원의 정보가 전달된다는 가정하에 작성하여 추후 수정이 필요함
+		suggestedProductService.createSuggestedProduct(request);
+	}
+}

--- a/src/main/java/com/barter/domain/product/dto/request/CreateSuggestedProductReqDto.java
+++ b/src/main/java/com/barter/domain/product/dto/request/CreateSuggestedProductReqDto.java
@@ -1,0 +1,24 @@
+package com.barter.domain.product.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CreateSuggestedProductReqDto {
+
+	@NotNull
+	@Size(min = 5)
+	private String name;
+
+	@NotNull
+	@Size(min = 5)
+	private String description;
+
+	@NotNull
+	private String images;
+
+	// 인증/인가 전 테스트를 위해 RequestBody 에 요청 회원의 ID 를 전달받도록 함, 이후 삭제 예정
+	@NotNull
+	private Long memberId;
+}

--- a/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
+++ b/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
@@ -2,14 +2,17 @@ package com.barter.domain.product.entity;
 
 import com.barter.domain.BaseTimeStampEntity;
 import com.barter.domain.member.entity.Member;
+import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,7 +27,24 @@ public class SuggestedProduct extends BaseTimeStampEntity {
 	private Long id;
 	private String name;
 	private String description;
-	private String image;
-	@ManyToOne
+	private String images;
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Member member;
+
+	@Builder
+	public SuggestedProduct(String name, String description, String images, Member member) {
+		this.name = name;
+		this.description = description;
+		this.images = images;
+		this.member = member;
+	}
+
+	public static SuggestedProduct create(CreateSuggestedProductReqDto request, Member member) {
+		return SuggestedProduct.builder()
+			.name(request.getName())
+			.description(request.getDescription())
+			.images(request.getImages())
+			.member(member)
+			.build();
+	}
 }

--- a/src/main/java/com/barter/domain/product/repository/SuggestedProductRepository.java
+++ b/src/main/java/com/barter/domain/product/repository/SuggestedProductRepository.java
@@ -1,0 +1,8 @@
+package com.barter.domain.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.barter.domain.product.entity.SuggestedProduct;
+
+public interface SuggestedProductRepository extends JpaRepository<SuggestedProduct, Long> {
+}

--- a/src/main/java/com/barter/domain/product/service/SuggestedProductService.java
+++ b/src/main/java/com/barter/domain/product/service/SuggestedProductService.java
@@ -1,0 +1,28 @@
+package com.barter.domain.product.service;
+
+import org.springframework.stereotype.Service;
+
+import com.barter.domain.member.entity.Member;
+import com.barter.domain.member.repository.MemberRepository;
+import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
+import com.barter.domain.product.entity.SuggestedProduct;
+import com.barter.domain.product.repository.SuggestedProductRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SuggestedProductService {
+
+	private final SuggestedProductRepository suggestedProductRepository;
+	private final MemberRepository memberRepository;
+
+	// RegisteredProductController 와 마찬가지로 요청 회원의 정보가 넘어와야 하므로 인증/인가 구현 완료 이후 수정이 필요함
+	public void createSuggestedProduct(CreateSuggestedProductReqDto request) {
+		Member requestMember = memberRepository.findById(request.getMemberId())
+			.orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+		SuggestedProduct createdProduct = SuggestedProduct.create(request, requestMember);
+		suggestedProductRepository.save(createdProduct);
+	}
+}


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `제안 물품` 생성(추가) 할 때 사용되는 기능을 구현했습니다.
- 현재 인증/인가가 구현되지 않아 `RequestBody` 에 요청 회원의 ID 를 전달하고 이를 통해 `MemberRepository` 에서 요청 회원이 유효한지 확인 후 `제안 물품` 정보를 DB 에 저장하도록 하였습니다.
    - 인증/인가 구현 후 해당 부분은 추가 수정할 계획입니다.
- API Test 는 Postman 으로 진행했고 진행과정은 `MEMBERS` 테이블에 임시 회원정보를 추가, `API(POST /suggested-products)` 요청을 날려 `SUGGESTED_PRODUCTS` 테이블에 `제안 물품` 정보가 저장되는 확인하였습니다. 

Resolves: #15 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제