### PR TITLE
[FEAT] 등록 물품 단건 조회 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
@@ -1,6 +1,8 @@
 package com.barter.domain.product.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -8,6 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
+import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.service.RegisteredProductService;
 
 import jakarta.validation.Valid;
@@ -25,5 +28,16 @@ public class RegisteredProductController {
 	public void createRegisteredProduct(@RequestBody @Valid CreateRegisteredProductReqDto request) {
 		// 현재 인증/인가 파트의 구현이 완료되지 않아 요청 회원의 정보가 전달된다는 가정하에 작성하여 추후 수정이 필요함
 		registeredProductService.createRegisteredProduct(request);
+	}
+
+	@GetMapping("/{registeredProductId}")
+	@ResponseStatus(HttpStatus.OK)
+	public FindRegisteredProductResDto findRegisteredProduct(
+		@PathVariable(name = "registeredProductId") Long registeredProductId
+	) {
+		// 현재 인증/인가 파트의 구현이 완료되지 않아 요청 회원의 ID 정보를 전달 받지 못하고 있습니다.
+		// 구현 이후 해당 메서드의 파라미터로 요청 회원 정보를 전달받아 활용하는 쪽으로 수정할 계획입니다.
+
+		return registeredProductService.findRegisteredProduct(registeredProductId);
 	}
 }

--- a/src/main/java/com/barter/domain/product/dto/response/FindRegisteredProductResDto.java
+++ b/src/main/java/com/barter/domain/product/dto/response/FindRegisteredProductResDto.java
@@ -1,0 +1,29 @@
+package com.barter.domain.product.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.barter.domain.product.entity.RegisteredProduct;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindRegisteredProductResDto {
+
+	private Long id;
+	private String name;
+	private String description;
+	private String images;
+	private LocalDateTime createdAt;
+
+	public static FindRegisteredProductResDto from(RegisteredProduct product) {
+		return FindRegisteredProductResDto.builder()
+			.id(product.getId())
+			.name(product.getName())
+			.description(product.getDescription())
+			.images(product.getImages())
+			.createdAt(product.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
+++ b/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.member.repository.MemberRepository;
 import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
+import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.entity.RegisteredProduct;
 import com.barter.domain.product.repository.RegisteredProductRepository;
 
@@ -24,5 +25,13 @@ public class RegisteredProductService {
 
 		RegisteredProduct createdProduct = RegisteredProduct.create(request, requestMember);
 		registeredProductRepository.save(createdProduct);
+	}
+
+	// 인증/인가가 구현되면 요청 회원 정보를 파라미터로 전달받아 요청한 '등록 물품' 등록자가 요청 회원인지 확인하는 로직을 추가 작성할 것 입니다.
+	public FindRegisteredProductResDto findRegisteredProduct(Long RegisteredProductId) {
+		RegisteredProduct foundProduct = registeredProductRepository.findById(RegisteredProductId)
+			.orElseThrow(() -> new IllegalArgumentException("Registered product not found"));
+
+		return FindRegisteredProductResDto.from(foundProduct);
 	}
 }


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 특정 `등록 물품` 에 대한 정보를 조회하는 기능을 구현하였습니다.
- 인증/인가가 구현된다면 요청 회원이 조회하려는 `등록 물품` 의 등록자인지를 확인하는 로직을 `RegisteredProductService.findRegisteredProduct()` 에 추가할 것 같습니다.

Resolves: #20

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제