### PR TITLE
[FEAT] 등록 물품 다건 조회 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
@@ -1,11 +1,15 @@
 package com.barter.domain.product.controller;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,5 +43,19 @@ public class RegisteredProductController {
 		// 구현 이후 해당 메서드의 파라미터로 요청 회원 정보를 전달받아 활용하는 쪽으로 수정할 계획입니다.
 
 		return registeredProductService.findRegisteredProduct(registeredProductId);
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public PagedModel<FindRegisteredProductResDto> findRegisteredProducts(
+		@RequestParam(name = "pageNum", defaultValue = "1") int pageNum,
+		@RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
+		// 인증/인가 파트 구현이 끝난다면, 'REGISTERED_PRODUCTS' 테이블에서 요청 회원이 생성한 등록 물품들을 조회하도록 할 것 같습니다.
+
+		PageRequest pageRequest = PageRequest.of(
+			pageNum - 1, pageSize, Sort.Direction.DESC, "createdAt"
+		);
+
+		return registeredProductService.findRegisteredProducts(pageRequest);
 	}
 }

--- a/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
@@ -1,7 +1,8 @@
 package com.barter.domain.product.controller;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,7 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -48,14 +48,9 @@ public class RegisteredProductController {
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
 	public PagedModel<FindRegisteredProductResDto> findRegisteredProducts(
-		@RequestParam(name = "pageNum", defaultValue = "1") int pageNum,
-		@RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
+		@PageableDefault(sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable) {
 		// 인증/인가 파트 구현이 끝난다면, 'REGISTERED_PRODUCTS' 테이블에서 요청 회원이 생성한 등록 물품들을 조회하도록 할 것 같습니다.
 
-		PageRequest pageRequest = PageRequest.of(
-			pageNum - 1, pageSize, Sort.Direction.DESC, "createdAt"
-		);
-
-		return registeredProductService.findRegisteredProducts(pageRequest);
+		return registeredProductService.findRegisteredProducts(pageable);
 	}
 }

--- a/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
+++ b/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
@@ -1,5 +1,8 @@
 package com.barter.domain.product.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 
 import com.barter.domain.member.entity.Member;
@@ -33,5 +36,13 @@ public class RegisteredProductService {
 			.orElseThrow(() -> new IllegalArgumentException("Registered product not found"));
 
 		return FindRegisteredProductResDto.from(foundProduct);
+	}
+
+	// 인증/인가 구현되면 요청 회원이 생성한 '등록 물품들만' 조회하도록 수정할 것으로 보입니다.
+	public PagedModel<FindRegisteredProductResDto> findRegisteredProducts(Pageable pageable) {
+		Page<FindRegisteredProductResDto> foundProducts = registeredProductRepository.findAll(pageable)
+			.map(FindRegisteredProductResDto::from);
+
+		return new PagedModel<>(foundProducts);
 	}
 }


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `REGISTERED_PRODUCTS` 테이블에서 다수의 `등록 물품` 정보를 조회하는 기능을 구현했습니다.
- 현재는 전체 테이블의 정보를 대상으로 페이징 처리를 하지만 인증/인가가 구현되면 요청 회원의 ID 를 가진 `등록 물품` 을 대상으로 페이징 처리를 하게 될 것 같습니다.

Resolves: #28

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제