### PR TITLE
[REFACTOR] 등록 물품 및 제안 물품 status 추가

### DIFF
--- a/src/main/java/com/barter/domain/product/dto/response/FindRegisteredProductResDto.java
+++ b/src/main/java/com/barter/domain/product/dto/response/FindRegisteredProductResDto.java
@@ -16,6 +16,7 @@ public class FindRegisteredProductResDto {
 	private String description;
 	private String images;
 	private LocalDateTime createdAt;
+	private String status;
 
 	public static FindRegisteredProductResDto from(RegisteredProduct product) {
 		return FindRegisteredProductResDto.builder()
@@ -24,6 +25,7 @@ public class FindRegisteredProductResDto {
 			.description(product.getDescription())
 			.images(product.getImages())
 			.createdAt(product.getCreatedAt())
+			.status(product.getStatus().name())
 			.build();
 	}
 }

--- a/src/main/java/com/barter/domain/product/entity/RegisteredProduct.java
+++ b/src/main/java/com/barter/domain/product/entity/RegisteredProduct.java
@@ -3,8 +3,11 @@ package com.barter.domain.product.entity;
 import com.barter.domain.BaseTimeStampEntity;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
+import com.barter.domain.product.enums.RegisteredStatus;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,15 +31,18 @@ public class RegisteredProduct extends BaseTimeStampEntity {
 	private String name;
 	private String description;
 	private String images;
+	@Enumerated(EnumType.STRING)
+	private RegisteredStatus status;
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Member member;
 
 	@Builder
-	public RegisteredProduct(String name, String description, String images, Member member) {
+	public RegisteredProduct(String name, String description, String images, Member member, RegisteredStatus status) {
 		this.name = name;
 		this.description = description;
 		this.images = images;
 		this.member = member;
+		this.status = status;
 	}
 
 	public static RegisteredProduct create(CreateRegisteredProductReqDto request, Member member) {
@@ -45,6 +51,7 @@ public class RegisteredProduct extends BaseTimeStampEntity {
 			.description(request.getDescription())
 			.images(request.getImages())
 			.member(member)
+			.status(RegisteredStatus.PENDING)
 			.build();
 	}
 

--- a/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
+++ b/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
@@ -3,8 +3,11 @@ package com.barter.domain.product.entity;
 import com.barter.domain.BaseTimeStampEntity;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
+import com.barter.domain.product.enums.SuggestedStatus;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -28,15 +31,18 @@ public class SuggestedProduct extends BaseTimeStampEntity {
 	private String name;
 	private String description;
 	private String images;
+	@Enumerated(EnumType.STRING)
+	private SuggestedStatus status;
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Member member;
 
 	@Builder
-	public SuggestedProduct(String name, String description, String images, Member member) {
+	public SuggestedProduct(String name, String description, String images, Member member, SuggestedStatus status) {
 		this.name = name;
 		this.description = description;
 		this.images = images;
 		this.member = member;
+		this.status = status;
 	}
 
 	public static SuggestedProduct create(CreateSuggestedProductReqDto request, Member member) {
@@ -45,6 +51,7 @@ public class SuggestedProduct extends BaseTimeStampEntity {
 			.description(request.getDescription())
 			.images(request.getImages())
 			.member(member)
+			.status(SuggestedStatus.PENDING)
 			.build();
 	}
 }

--- a/src/main/java/com/barter/domain/product/enums/RegisteredStatus.java
+++ b/src/main/java/com/barter/domain/product/enums/RegisteredStatus.java
@@ -1,0 +1,5 @@
+package com.barter.domain.product.enums;
+
+public enum RegisteredStatus {
+	PENDING, REGISTERING, ACCEPTED
+}

--- a/src/main/java/com/barter/domain/product/enums/SuggestedStatus.java
+++ b/src/main/java/com/barter/domain/product/enums/SuggestedStatus.java
@@ -1,0 +1,5 @@
+package com.barter.domain.product.enums;
+
+public enum SuggestedStatus {
+	PENDING, SUGGESTING, ACCEPTED
+}

--- a/src/main/java/com/barter/domain/product/repository/TradeProductRepository.java
+++ b/src/main/java/com/barter/domain/product/repository/TradeProductRepository.java
@@ -1,0 +1,8 @@
+package com.barter.domain.product.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.barter.domain.product.entity.TradeProduct;
+
+public interface TradeProductRepository extends JpaRepository<TradeProduct, Long> {
+}


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `RegisterdProduct`, `SuggestedProduct` 클래스에 `status` 필드를 각각 추가했습니다.
- `status` 필드 추가로 인해 아래의 내용을 반영/수정 하였습니다.
    - 각 엔티티가 사용할 상태 값을 갖는 Enum 클래스를 별도로 생성했습니다.
        - 추후에 두 엔티티가 갖는 상태가 달라질 것을 염두해 별도로 생성하게 되었습니다.
        - 각 Enum 클래스가 갖는 열거 상수는 아래의 이슈 번호를 통해 확인하실 수 있습니다.
    - 각 엔티티 생성시 `PEDING` 을 기본적으로 갖도록 생성 메서드를 수정했습니다.
    - `등록 물품` 조회(다건, 단건)시 응답 값에 `status` 가 포함되도록 응답 DTO 의 필드와 생성 메서드를 수정하였습니다.

Resolves: #40

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제