### PR TITLE
refactor : periodTrade 에서의 registered_product 상태 변경 및 PeriodTrade 엔티티티 필드명 변경

### DIFF
--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/response/CreatePeriodTradeResDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/response/CreatePeriodTradeResDto.java
@@ -44,7 +44,7 @@ public class CreatePeriodTradeResDto {
 			.periodTradesId(periodTrade.getId())
 			.title(periodTrade.getTitle())
 			.description(periodTrade.getDescription())
-			.product(periodTrade.getProduct())
+			.product(periodTrade.getRegisteredProduct())
 			.createdAt(periodTrade.getCreatedAt())
 			.updatedAt(periodTrade.getUpdatedAt())
 			.viewCount(periodTrade.getViewCount())

--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/response/FindPeriodTradeResDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/response/FindPeriodTradeResDto.java
@@ -44,7 +44,7 @@ public class FindPeriodTradeResDto {
 			.periodTradesId(periodTrade.getId())
 			.title(periodTrade.getTitle())
 			.description(periodTrade.getDescription())
-			.product(periodTrade.getProduct())
+			.product(periodTrade.getRegisteredProduct())
 			.createdAt(periodTrade.getCreatedAt())
 			.updatedAt(periodTrade.getUpdatedAt())
 			.viewCount(periodTrade.getViewCount())

--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/response/UpdatePeriodTradeResDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/response/UpdatePeriodTradeResDto.java
@@ -44,7 +44,7 @@ public class UpdatePeriodTradeResDto {
 			.periodTradesId(periodTrade.getId())
 			.title(periodTrade.getTitle())
 			.description(periodTrade.getDescription())
-			.product(periodTrade.getProduct())
+			.product(periodTrade.getRegisteredProduct())
 			.createdAt(periodTrade.getCreatedAt())
 			.updatedAt(periodTrade.getUpdatedAt())
 			.viewCount(periodTrade.getViewCount())

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -120,7 +120,7 @@ public class PeriodTradeService {
 		periodTrade.validateIsPending();
 		periodTrade.validateIsCompleted();
 
-		List<SuggestedProduct> suggestedProduct = findRegisteredProductByIds(reqDto.getProductIds());
+		List<SuggestedProduct> suggestedProduct = findSuggestedProductByIds(reqDto.getProductIds());
 
 		List<TradeProduct> tradeProducts = suggestedProduct.stream()
 			.map(product -> TradeProduct.createTradeProduct(
@@ -150,6 +150,8 @@ public class PeriodTradeService {
 
 		// TODO : PeriodTrade 엔티티의 endedAt 이 현재 시간과 비교시 이후인 경우 CLOSED 되도록 하는 기능 구현 필요
 
+		// TODO : 완료 상태 시에 REGISTERED_PRODUCT 완료 상태 변경 필요
+
 		return StatusUpdateResDto.from(periodTrade);
 	}
 
@@ -171,6 +173,8 @@ public class PeriodTradeService {
 
 			if (suggestedProduct.getMember().getId().equals(reqDto.getMemberId())) {
 				suggestedProduct.changStatusAccepted();
+				periodTrade.getRegisteredProduct()
+					.updateStatus("ACCEPTED");// enum 타입이 아니어도 검증 로직이 구현되어 있기 때문에 일단 이렇게 구현함
 			}
 
 			// 한 교환에 대해서 여러번의 교환은 불가능 (회의 때 말한 같은 물건으로 여러번 다른 교환 시도 방지 위함)
@@ -183,7 +187,7 @@ public class PeriodTradeService {
 
 	}
 
-	private List<SuggestedProduct> findRegisteredProductByIds(List<Long> productIds) {
+	private List<SuggestedProduct> findSuggestedProductByIds(List<Long> productIds) {
 		return productIds.stream()
 			.map(id -> {
 					SuggestedProduct product = suggestedProductRepository.findById(id)


### PR DESCRIPTION
… 필드명 변경

## 개요
1. periodTrade 가 상태 업데이트 및 수락되면 기존에 없던 registered_product 의 상태변경 기능을 추가
2. PeriodTrade 의 필드명 product 를 registeredProduct 로 변경 

Resolves: #79 

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제