### PR TITLE
feat : periodTrade 제안 거절 구현

### DIFF
--- a/src/main/java/com/barter/domain/product/enums/RegisteredStatus.java
+++ b/src/main/java/com/barter/domain/product/enums/RegisteredStatus.java
@@ -1,7 +1,7 @@
 package com.barter.domain.product.enums;
 
 public enum RegisteredStatus {
-	PENDING, REGISTERING, ACCEPTED;
+	PENDING, IN_PROGRESS, REGISTERING, ACCEPTED;
 
 	public static RegisteredStatus findRegisteredStatus(String status) {
 		for (RegisteredStatus registeredStatus : RegisteredStatus.values()) {

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -15,11 +15,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.trade.periodtrade.dto.request.AcceptPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.CreatePeriodTradeReqDto;
+import com.barter.domain.trade.periodtrade.dto.request.DenyPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.StatusUpdateReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.SuggestedPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.UpdatePeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.response.AcceptPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.CreatePeriodTradeResDto;
+import com.barter.domain.trade.periodtrade.dto.response.DenyPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.FindPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.StatusUpdateResDto;
 import com.barter.domain.trade.periodtrade.dto.response.SuggestedPeriodTradeResDto;
@@ -99,6 +101,15 @@ public class PeriodTradeController {
 		@Valid @RequestBody AcceptPeriodTradeReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(
 			periodTradeService.acceptPeriodTrade(id, reqDto)
+		);
+	}
+
+	@PatchMapping("/period-trades/{id}/denial")
+	public ResponseEntity<DenyPeriodTradeResDto> denyPeriodTrade(
+		@PathVariable Long id,
+		@Valid @RequestBody DenyPeriodTradeReqDto reqDto) {
+		return ResponseEntity.status(HttpStatus.OK).body(
+			periodTradeService.denyPeriodTrade(id, reqDto)
 		);
 	}
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/request/DenyPeriodTradeReqDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/request/DenyPeriodTradeReqDto.java
@@ -1,0 +1,9 @@
+package com.barter.domain.trade.periodtrade.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class DenyPeriodTradeReqDto {
+	private Long memberId;
+	//Restful 하게 uri 하려면 pathVariable 보다는 이런식으로 넣는게 좋다고 생각했습니다.
+}

--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/response/DenyPeriodTradeResDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/response/DenyPeriodTradeResDto.java
@@ -1,0 +1,35 @@
+package com.barter.domain.trade.periodtrade.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.barter.domain.trade.enums.TradeStatus;
+import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DenyPeriodTradeResDto {
+	private Long periodTradeId;
+	private LocalDateTime deniedAt;
+	private TradeStatus tradeStatus;
+
+	@Builder
+	public DenyPeriodTradeResDto(Long periodTradeId, TradeStatus tradeStatus) {
+		this.periodTradeId = periodTradeId;
+		this.deniedAt = LocalDateTime.now();
+		this.tradeStatus = tradeStatus;
+	}
+
+	public static DenyPeriodTradeResDto from(PeriodTrade periodTrade) {
+		return DenyPeriodTradeResDto
+			.builder()
+			.periodTradeId(periodTrade.getId())
+			.tradeStatus(periodTrade.getStatus())
+			.build();
+
+	}
+}

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -206,7 +206,7 @@ public class PeriodTradeService {
 			if (suggestedProduct.getMember().getId().equals(reqDto.getMemberId())) {
 				suggestedProduct.changStatusPending();
 				periodTrade.getRegisteredProduct()
-					.updateStatus("PENDING");
+					.updateStatus("IN_PROGRESS");
 			}
 
 		}

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -18,11 +18,13 @@ import com.barter.domain.product.repository.SuggestedProductRepository;
 import com.barter.domain.product.repository.TradeProductRepository;
 import com.barter.domain.trade.periodtrade.dto.request.AcceptPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.CreatePeriodTradeReqDto;
+import com.barter.domain.trade.periodtrade.dto.request.DenyPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.StatusUpdateReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.SuggestedPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.UpdatePeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.response.AcceptPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.CreatePeriodTradeResDto;
+import com.barter.domain.trade.periodtrade.dto.response.DenyPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.FindPeriodTradeResDto;
 import com.barter.domain.trade.periodtrade.dto.response.StatusUpdateResDto;
 import com.barter.domain.trade.periodtrade.dto.response.SuggestedPeriodTradeResDto;
@@ -150,8 +152,6 @@ public class PeriodTradeService {
 
 		// TODO : PeriodTrade 엔티티의 endedAt 이 현재 시간과 비교시 이후인 경우 CLOSED 되도록 하는 기능 구현 필요
 
-		// TODO : 완료 상태 시에 REGISTERED_PRODUCT 완료 상태 변경 필요
-
 		return StatusUpdateResDto.from(periodTrade);
 	}
 
@@ -185,6 +185,32 @@ public class PeriodTradeService {
 
 		return AcceptPeriodTradeResDto.from(periodTrade);
 
+	}
+
+	// TODO : Deny 부분이 Accept 랑 구조가 비슷해서 단순화 시킬 필요 있다.
+	@Transactional
+	public DenyPeriodTradeResDto denyPeriodTrade(Long id, DenyPeriodTradeReqDto reqDto) {
+		Long userId = 1L;
+
+		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
+			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
+		);
+		periodTrade.validateAuthority(userId);
+		periodTrade.validateIsCompleted();
+
+		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(id, TradeType.PERIOD);
+
+		for (TradeProduct tradeProduct : tradeProducts) {
+			SuggestedProduct suggestedProduct = tradeProduct.getSuggestedProduct();
+
+			if (suggestedProduct.getMember().getId().equals(reqDto.getMemberId())) {
+				suggestedProduct.changStatusPending();
+				periodTrade.getRegisteredProduct()
+					.updateStatus("PENDING");
+			}
+
+		}
+		return DenyPeriodTradeResDto.from(periodTrade);
 	}
 
 	private List<SuggestedProduct> findSuggestedProductByIds(List<Long> productIds) {


### PR DESCRIPTION
## 개요

1. Trade_Products 테이블에 등록되어 있는 제안 중 특정 memberId 값의 제안을 수락하는 기능
2. tradeProduct 테이블의 정보를 조회한다. (조건 : 동일 tradeId 및 동일 타입의 tradeType)
3. 조회한 정보들 중 requestbody 로 받은 memberId 값을 가진 것을 조회해서 그것을 PENDING 상태로 변경
4. periodTrade 상태는 INPROGRESS 로 유지

Resolves: #70 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제