### PR TITLE
feat: 사용자가 단어로 검색했을 때의 로직 구현

### DIFF
--- a/src/main/java/com/barter/domain/search/controller/SearchController.java
+++ b/src/main/java/com/barter/domain/search/controller/SearchController.java
@@ -1,0 +1,28 @@
+package com.barter.domain.search.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.barter.domain.search.dto.SearchTradeResDto;
+import com.barter.domain.search.service.SearchService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class SearchController {
+	private final SearchService searchService;
+
+	// 반환 타입은 뭘로 해야할까 ? 세 종류의 교환(trade)가 있음. 각 서비스와 레포지토리로 구분함. List 로 묶어서 보내봐야겠다.
+	@PostMapping("/{word}")
+	public ResponseEntity<List<SearchTradeResDto>> FindTrades(@PathVariable String word) {
+		return new ResponseEntity<>(searchService.createSearchKeywordAndFindTrades(word), HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/barter/domain/search/controller/SearchController.java
+++ b/src/main/java/com/barter/domain/search/controller/SearchController.java
@@ -22,7 +22,7 @@ public class SearchController {
 
 	// 반환 타입은 뭘로 해야할까 ? 세 종류의 교환(trade)가 있음. 각 서비스와 레포지토리로 구분함. List 로 묶어서 보내봐야겠다.
 	@PostMapping("/{word}")
-	public ResponseEntity<List<SearchTradeResDto>> FindTrades(@PathVariable String word) {
+	public ResponseEntity<List<SearchTradeResDto>> findTrades(@PathVariable String word) {
 		return new ResponseEntity<>(searchService.createSearchKeywordAndFindTrades(word), HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
+++ b/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
@@ -1,0 +1,27 @@
+package com.barter.domain.search.dto;
+
+import com.barter.domain.product.entity.RegisteredProduct;
+import com.barter.domain.trade.enums.TradeStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SearchTradeResDto {
+
+	private String title;
+	private RegisteredProduct product;
+	private TradeStatus tradeStatus;
+	private int viewCount;
+
+	@Builder
+	public SearchTradeResDto(String title, RegisteredProduct product, TradeStatus tradeStatus, int viewCount) {
+		this.title = title;
+		this.product = product;
+		this.tradeStatus = tradeStatus;
+		this.viewCount = viewCount;
+	}
+
+}

--- a/src/main/java/com/barter/domain/search/entity/SearchHistory.java
+++ b/src/main/java/com/barter/domain/search/entity/SearchHistory.java
@@ -1,0 +1,40 @@
+package com.barter.domain.search.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+// 검색 기록 관리 테이블, 24시간 주기로 관리됨
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "SEARCH_HISTORY")
+public class SearchHistory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "keyword_id", nullable = false)
+	private SearchKeyword searchKeyword;
+
+	@Column(nullable = false)
+	private LocalDateTime searchedAt;
+
+	@Builder
+	public SearchHistory(SearchKeyword searchKeyword) {
+		this.searchKeyword = searchKeyword;
+		this.searchedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/barter/domain/search/entity/SearchKeyword.java
+++ b/src/main/java/com/barter/domain/search/entity/SearchKeyword.java
@@ -1,22 +1,41 @@
 package com.barter.domain.search.entity;
 
+import com.barter.domain.BaseTimeStampEntity;
+
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+// 검색어 및 해당 24시간 내 몇 번 검색되었는지 count
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "SEARCH_KEYWORDS")
-public class SearchKeyword {
+public class SearchKeyword extends BaseTimeStampEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-	private String keyword;
+
+	@Column(nullable = false, unique = true)
+	private String word;
+
+	@Column(nullable = false)
+	private Long count = 0L;
+
+	@Builder
+	public SearchKeyword(String word) {
+		this.word = word;
+	}
+
+	public void updateCount(Long newCount) {
+		this.count = newCount;
+	}
 }

--- a/src/main/java/com/barter/domain/search/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/barter/domain/search/repository/SearchHistoryRepository.java
@@ -1,0 +1,16 @@
+package com.barter.domain.search.repository;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.barter.domain.search.entity.SearchHistory;
+
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+	@Query("SELECT COUNT(h) FROM SearchHistory h WHERE h.searchKeyword.id = :keywordId AND h.searchedAt >= :since")
+	Long countRecentSearches(@Param("keywordId") Long keywordId, @Param("since") LocalDateTime since);
+}
+

--- a/src/main/java/com/barter/domain/search/repository/SearchKeywordRepository.java
+++ b/src/main/java/com/barter/domain/search/repository/SearchKeywordRepository.java
@@ -1,0 +1,11 @@
+package com.barter.domain.search.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.barter.domain.search.entity.SearchKeyword;
+
+public interface SearchKeywordRepository extends JpaRepository<SearchKeyword, Long> {
+	Optional<SearchKeyword> findByWord(String word);
+}

--- a/src/main/java/com/barter/domain/search/service/SearchService.java
+++ b/src/main/java/com/barter/domain/search/service/SearchService.java
@@ -1,0 +1,112 @@
+package com.barter.domain.search.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.barter.domain.search.dto.SearchTradeResDto;
+import com.barter.domain.search.entity.SearchHistory;
+import com.barter.domain.search.entity.SearchKeyword;
+import com.barter.domain.search.repository.SearchHistoryRepository;
+import com.barter.domain.search.repository.SearchKeywordRepository;
+import com.barter.domain.trade.donationtrade.entity.DonationTrade;
+import com.barter.domain.trade.donationtrade.repository.DonationTradeRepository;
+import com.barter.domain.trade.immediatetrade.entity.ImmediateTrade;
+import com.barter.domain.trade.immediatetrade.repository.ImmediateTradeRepository;
+import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
+import com.barter.domain.trade.periodtrade.repository.PeriodTradeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+	private final SearchKeywordRepository searchKeywordRepository;
+	private final SearchHistoryRepository searchHistoryRepository;
+	private final DonationTradeRepository donationTradeRepository;
+	private final ImmediateTradeRepository immediateTradeRepository;
+	private final PeriodTradeRepository periodTradeRepository;
+
+	@Transactional
+	public List<SearchTradeResDto> createSearchKeywordAndFindTrades(String word) {
+
+		// 검색어 찾고 없다면 생성
+		SearchKeyword searchKeyword = searchKeywordRepository.findByWord(word)
+			.orElseGet(() ->
+				searchKeywordRepository.save(SearchKeyword.builder()
+					.word(word)
+					.build()
+				));
+
+		// 검색 이력에 저장
+		searchHistoryRepository.save(SearchHistory.builder()
+			.searchKeyword(searchKeyword)
+			.build()
+		);
+
+		// 24시간 내 검색 횟수 계산
+		LocalDateTime since = LocalDateTime.now().minusHours(24);
+		Long recentCount = searchHistoryRepository.countRecentSearches(searchKeyword.getId(), since);
+
+		// 검색 count 업데이트
+		searchKeyword.updateCount(recentCount);
+		searchKeywordRepository.save(searchKeyword);
+
+		// 검색어로 교환 찾기
+		List<DonationTrade> donationTrades = donationTradeRepository.findByTitleOrDescriptionContaining(word, word);
+		List<ImmediateTrade> immediateTrades = immediateTradeRepository.findByTitleOrDescriptionContaining(word, word);
+		List<PeriodTrade> periodTrades = periodTradeRepository.findByTitleOrDescriptionContaining(word, word);
+
+		// 찾은 교환 List 를 변환하여 추가
+		List<SearchTradeResDto> tradeDtos = new ArrayList<>();
+		tradeDtos.addAll(mapDonationTradesToSearchTradeRes(donationTrades));
+		tradeDtos.addAll(mapImmediateTradesToSearchTradeRes(immediateTrades));
+		tradeDtos.addAll(mapPeriodTradesToSearchTradeRes(periodTrades));
+
+		if (tradeDtos.isEmpty()) {
+			tradeDtos.add(SearchTradeResDto.builder()
+				.title("검색 결과가 없습니다.")
+				.build());
+		}
+
+		return tradeDtos;
+	}
+
+	private List<SearchTradeResDto> mapDonationTradesToSearchTradeRes(List<DonationTrade> trades) {
+		return trades.stream()
+			.map(trade -> SearchTradeResDto.builder()
+				.title(trade.getTitle())
+				.product(trade.getProduct())
+				.tradeStatus(trade.getStatus())
+				.viewCount(trade.getViewCount())
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private List<SearchTradeResDto> mapImmediateTradesToSearchTradeRes(List<ImmediateTrade> trades) {
+		return trades.stream()
+			.map(trade -> SearchTradeResDto.builder()
+				.title(trade.getTitle())
+				.product(trade.getProduct())
+				.tradeStatus(trade.getStatus())
+				.viewCount(trade.getViewCount())
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private List<SearchTradeResDto> mapPeriodTradesToSearchTradeRes(List<PeriodTrade> trades) {
+		return trades.stream()
+			.map(trade -> SearchTradeResDto.builder()
+				.title(trade.getTitle())
+				.product(trade.getRegisteredProduct())
+				.tradeStatus(trade.getStatus())
+				.viewCount(trade.getViewCount())
+				.build())
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
@@ -1,5 +1,6 @@
 package com.barter.domain.trade.donationtrade.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface DonationTradeRepository extends JpaRepository<DonationTrade, Lo
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("select d from DonationTrade d where d.id = :tradeId")
 	Optional<DonationTrade> findByIdForUpdate(Long tradeId);
+
+	List<DonationTrade> findByTitleOrDescriptionContaining(String title, String description);
 }

--- a/src/main/java/com/barter/domain/trade/immediatetrade/repository/ImmediateTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/repository/ImmediateTradeRepository.java
@@ -1,8 +1,12 @@
 package com.barter.domain.trade.immediatetrade.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.barter.domain.trade.immediatetrade.entity.ImmediateTrade;
 
 public interface ImmediateTradeRepository extends JpaRepository<ImmediateTrade, Long> {
+
+	List<ImmediateTrade> findByTitleOrDescriptionContaining(String title, String description);
 }

--- a/src/main/java/com/barter/domain/trade/periodtrade/repository/PeriodTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/repository/PeriodTradeRepository.java
@@ -1,8 +1,12 @@
 package com.barter.domain.trade.periodtrade.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
 
 public interface PeriodTradeRepository extends JpaRepository<PeriodTrade, Long> {
+
+	List<PeriodTrade> findByTitleOrDescriptionContaining(String title, String description);
 }


### PR DESCRIPTION


[#99]

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 코드가 많아서 제 생각 흐름인 주석을 되도록이면 삭제하지 않았습니다.
- 아직 top10 인기 검색어 구현하지 않았습니다.
- 정리가 필요합니다. 

```
	private List<SearchTradeResDto> mapDonationTradesToSearchTradeRes(List<DonationTrade> trades) {
		return trades.stream()
			.map(trade -> SearchTradeResDto.builder()
				.title(trade.getTitle())
				.product(trade.getProduct())
				.tradeStatus(trade.getStatus())
				.viewCount(trade.getViewCount())
				.build())
			.collect(Collectors.toList());
	}
```

와 비슷한 메서드가 셋인데, 이건 교환이 세 종류라 그렇습니다. 

추상 클래스 만들어서 공통 필드를 상속받게 하려고 생각했지만, 이미 timeStamp를 상속 받고 있어서 적용하지 못했습니다.

인터페이스로할까 생각 중이긴 한데, 나중에 리팩토링할 때 적용해보겠습니다.


<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제