### PR TITLE
feat : 관심 키워드 생성

### DIFF
--- a/src/main/java/com/barter/common/KeywordHelper.java
+++ b/src/main/java/com/barter/common/KeywordHelper.java
@@ -1,0 +1,8 @@
+package com.barter.common;
+
+public class KeywordHelper {
+
+	public static String removeSpace(String keyword) {
+		return keyword.replaceAll("\\s+", "");
+	}
+}

--- a/src/main/java/com/barter/domain/member/controller/FavoriteKeywordController.java
+++ b/src/main/java/com/barter/domain/member/controller/FavoriteKeywordController.java
@@ -1,0 +1,31 @@
+package com.barter.domain.member.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.barter.domain.member.dto.CreateFavoriteKeywordReqDto;
+import com.barter.domain.member.service.FavoriteKeywordService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/favorite-keywords")
+public class FavoriteKeywordController {
+
+	private final FavoriteKeywordService favoriteKeywordService;
+
+	@PostMapping
+	public ResponseEntity<Void> createFavoriteKeyword(@RequestBody CreateFavoriteKeywordReqDto req) {
+		// TODO: 인증/인가 개발 완료 시 교체 예정
+		Long memberId = 1L;
+		favoriteKeywordService.createFavoriteKeyword(memberId, req);
+		return ResponseEntity
+			.status(HttpStatus.CREATED)
+			.build();
+	}
+}

--- a/src/main/java/com/barter/domain/member/dto/CreateFavoriteKeywordReqDto.java
+++ b/src/main/java/com/barter/domain/member/dto/CreateFavoriteKeywordReqDto.java
@@ -1,0 +1,8 @@
+package com.barter.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateFavoriteKeywordReqDto {
+	private String keyword;
+}

--- a/src/main/java/com/barter/domain/member/entity/FavoriteKeyword.java
+++ b/src/main/java/com/barter/domain/member/entity/FavoriteKeyword.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,4 +20,10 @@ public class FavoriteKeyword {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private String keyword;
+
+	@Builder
+	public FavoriteKeyword(Long id, String keyword) {
+		this.id = id;
+		this.keyword = keyword;
+	}
 }

--- a/src/main/java/com/barter/domain/member/entity/MemberFavoriteKeyword.java
+++ b/src/main/java/com/barter/domain/member/entity/MemberFavoriteKeyword.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,11 @@ public class MemberFavoriteKeyword {
 	private Member member;
 	@ManyToOne
 	private FavoriteKeyword favoriteKeyword;
+
+	@Builder
+	public MemberFavoriteKeyword(Long id, Member member, FavoriteKeyword favoriteKeyword) {
+		this.id = id;
+		this.member = member;
+		this.favoriteKeyword = favoriteKeyword;
+	}
 }

--- a/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
+++ b/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
@@ -1,0 +1,11 @@
+package com.barter.domain.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.barter.domain.member.entity.FavoriteKeyword;
+
+public interface FavoriteKeywordRepository extends JpaRepository<FavoriteKeyword, Long> {
+	Optional<FavoriteKeyword> findByKeyword(String keyword);
+}

--- a/src/main/java/com/barter/domain/member/repository/MemberFavoriteKeywordRepository.java
+++ b/src/main/java/com/barter/domain/member/repository/MemberFavoriteKeywordRepository.java
@@ -1,0 +1,13 @@
+package com.barter.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.barter.domain.member.entity.FavoriteKeyword;
+import com.barter.domain.member.entity.Member;
+import com.barter.domain.member.entity.MemberFavoriteKeyword;
+
+public interface MemberFavoriteKeywordRepository extends JpaRepository<MemberFavoriteKeyword, Long> {
+	boolean existsByMemberAndFavoriteKeyword(Member member, FavoriteKeyword favoriteKeyword);
+
+	int countByMember(Member member);
+}

--- a/src/main/java/com/barter/domain/member/service/FavoriteKeywordService.java
+++ b/src/main/java/com/barter/domain/member/service/FavoriteKeywordService.java
@@ -1,0 +1,48 @@
+package com.barter.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.barter.common.KeywordHelper;
+import com.barter.domain.member.dto.CreateFavoriteKeywordReqDto;
+import com.barter.domain.member.entity.FavoriteKeyword;
+import com.barter.domain.member.entity.Member;
+import com.barter.domain.member.entity.MemberFavoriteKeyword;
+import com.barter.domain.member.repository.FavoriteKeywordRepository;
+import com.barter.domain.member.repository.MemberFavoriteKeywordRepository;
+import com.barter.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteKeywordService {
+
+	private static final int MAX_KEYWORD_COUNT = 3;
+	private final MemberRepository memberRepository;
+	private final FavoriteKeywordRepository favoriteKeywordRepository;
+	private final MemberFavoriteKeywordRepository memberFavoriteKeywordRepository;
+
+	@Transactional
+	public void createFavoriteKeyword(Long memberId, CreateFavoriteKeywordReqDto req) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+		String keyword = KeywordHelper.removeSpace(req.getKeyword());
+		FavoriteKeyword favoriteKeyword = favoriteKeywordRepository.findByKeyword(keyword)
+			.orElse(FavoriteKeyword.builder()
+				.keyword(keyword)
+				.build());
+		if (memberFavoriteKeywordRepository.existsByMemberAndFavoriteKeyword(member, favoriteKeyword)) {
+			throw new IllegalStateException("이미 관심키워드로 등록돼 있습니다.");
+		}
+		if (memberFavoriteKeywordRepository.countByMember(member) >= MAX_KEYWORD_COUNT) {
+			throw new IllegalStateException("관심 키워드는 3개까지만 등록 가능합니다.");
+		}
+		MemberFavoriteKeyword memberFavoriteKeyword = MemberFavoriteKeyword.builder()
+			.member(member)
+			.favoriteKeyword(favoriteKeyword)
+			.build();
+		favoriteKeywordRepository.save(favoriteKeyword);
+		memberFavoriteKeywordRepository.save(memberFavoriteKeyword);
+	}
+}

--- a/src/main/java/com/barter/domain/member/service/FavoriteKeywordService.java
+++ b/src/main/java/com/barter/domain/member/service/FavoriteKeywordService.java
@@ -29,9 +29,10 @@ public class FavoriteKeywordService {
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
 		String keyword = KeywordHelper.removeSpace(req.getKeyword());
 		FavoriteKeyword favoriteKeyword = favoriteKeywordRepository.findByKeyword(keyword)
-			.orElse(FavoriteKeyword.builder()
-				.keyword(keyword)
-				.build());
+			.orElseGet(() -> favoriteKeywordRepository.save(
+				FavoriteKeyword.builder()
+					.keyword(keyword)
+					.build()));
 		if (memberFavoriteKeywordRepository.existsByMemberAndFavoriteKeyword(member, favoriteKeyword)) {
 			throw new IllegalStateException("이미 관심키워드로 등록돼 있습니다.");
 		}
@@ -42,7 +43,6 @@ public class FavoriteKeywordService {
 			.member(member)
 			.favoriteKeyword(favoriteKeyword)
 			.build();
-		favoriteKeywordRepository.save(favoriteKeyword);
 		memberFavoriteKeywordRepository.save(memberFavoriteKeyword);
 	}
 }


### PR DESCRIPTION
## 개요
- 관심키워드 생성(등록) 기능 
- 들어오는 키워드의 공백제거 (탭, 공백, 줄바꿈 포함)
- 이미 관심키워드 테이블에 저장돼 있는 키워드면, 생성하지 않고 MemberFavoriteKeyword테이블에만 저장
- 없는 키워드라면 새로 생성하고, 저장
- 중복된 키워드가 이미 등록 돼 있다면 예외발생
- 관심 키워드 개수가 3개 이상이면 예외발생

    Resolves: #115 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제