### PR TITLE
feat : 관심 키워드 알림 전송

### DIFF
--- a/src/main/java/com/barter/common/KeywordHelper.java
+++ b/src/main/java/com/barter/common/KeywordHelper.java
@@ -1,8 +1,15 @@
 package com.barter.common;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class KeywordHelper {
 
 	public static String removeSpace(String keyword) {
 		return keyword.replaceAll("\\s+", "");
+	}
+
+	public static List<String> extractKeywords(String productName) {
+		return Arrays.stream(productName.split(" ")).toList();
 	}
 }

--- a/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
+++ b/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
@@ -1,11 +1,15 @@
 package com.barter.domain.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.barter.domain.member.entity.FavoriteKeyword;
 
 public interface FavoriteKeywordRepository extends JpaRepository<FavoriteKeyword, Long> {
 	Optional<FavoriteKeyword> findByKeyword(String keyword);
+
+	List<FavoriteKeyword> findByKeywordIn(@Param("keyword") List<String> keywords);
 }

--- a/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
+++ b/src/main/java/com/barter/domain/member/repository/FavoriteKeywordRepository.java
@@ -4,12 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
 import com.barter.domain.member.entity.FavoriteKeyword;
 
 public interface FavoriteKeywordRepository extends JpaRepository<FavoriteKeyword, Long> {
 	Optional<FavoriteKeyword> findByKeyword(String keyword);
 
-	List<FavoriteKeyword> findByKeywordIn(@Param("keyword") List<String> keywords);
+	List<FavoriteKeyword> findByKeywordIn(List<String> keywords);
 }

--- a/src/main/java/com/barter/domain/member/repository/MemberFavoriteKeywordRepository.java
+++ b/src/main/java/com/barter/domain/member/repository/MemberFavoriteKeywordRepository.java
@@ -14,4 +14,6 @@ public interface MemberFavoriteKeywordRepository extends JpaRepository<MemberFav
 	int countByMember(Member member);
 
 	List<MemberFavoriteKeyword> findByMember(Member member);
+
+	List<MemberFavoriteKeyword> findByFavoriteKeywordIn(List<FavoriteKeyword> keywords);
 }

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -1,5 +1,6 @@
 package com.barter.domain.trade.donationtrade.service;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -19,6 +20,7 @@ import com.barter.domain.trade.donationtrade.entity.DonationTrade;
 import com.barter.domain.trade.donationtrade.repository.DonationProductMemberRepository;
 import com.barter.domain.trade.donationtrade.repository.DonationTradeRepository;
 import com.barter.domain.trade.enums.DonationResult;
+import com.barter.event.trade.TradeNotificationEvent;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +32,7 @@ public class DonationTradeService {
 	private final RegisteredProductRepository registeredProductRepository;
 	private final DonationProductMemberRepository donationProductMemberRepository;
 	private final MemberRepository memberRepository;
+	private final ApplicationEventPublisher publisher;
 
 	@Transactional
 	public void createDonationTrade(Long userId, CreateDonationTradeReqDto req) {
@@ -44,7 +47,10 @@ public class DonationTradeService {
 			req.getEndedAt());
 
 		donationTrade.validateIsExceededMaxEndDate();
-		donationTradeRepository.save(donationTrade);
+		DonationTrade savedDonationTrade = donationTradeRepository.save(donationTrade);
+		Long savedTradeId = savedDonationTrade.getId();
+		String savedTradeProductName = savedDonationTrade.getProduct().getName();
+		publisher.publishEvent(new TradeNotificationEvent(savedTradeId, savedTradeProductName));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.member.repository.MemberRepository;
 import com.barter.domain.product.entity.RegisteredProduct;
+import com.barter.domain.product.enums.TradeType;
 import com.barter.domain.product.repository.RegisteredProductRepository;
 import com.barter.domain.trade.donationtrade.dto.request.CreateDonationTradeReqDto;
 import com.barter.domain.trade.donationtrade.dto.request.UpdateDonationTradeReqDto;
@@ -48,9 +49,11 @@ public class DonationTradeService {
 
 		donationTrade.validateIsExceededMaxEndDate();
 		DonationTrade savedDonationTrade = donationTradeRepository.save(donationTrade);
-		Long savedTradeId = savedDonationTrade.getId();
-		String savedTradeProductName = savedDonationTrade.getProduct().getName();
-		publisher.publishEvent(new TradeNotificationEvent(savedTradeId, savedTradeProductName));
+		publisher.publishEvent(TradeNotificationEvent.builder()
+			.tradeId(savedDonationTrade.getId())
+			.type(TradeType.DONATION)
+			.productName(savedDonationTrade.getProduct().getName())
+			.build());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/barter/event/trade/TradeNotificationEvent.java
+++ b/src/main/java/com/barter/event/trade/TradeNotificationEvent.java
@@ -1,11 +1,20 @@
 package com.barter.event.trade;
 
+import com.barter.domain.product.enums.TradeType;
+
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class TradeNotificationEvent {
 	private final Long tradeId;
+	private final TradeType type;
 	private final String productName;
+
+	@Builder
+	public TradeNotificationEvent(Long tradeId, TradeType type, String productName) {
+		this.tradeId = tradeId;
+		this.type = type;
+		this.productName = productName;
+	}
 }

--- a/src/main/java/com/barter/event/trade/TradeNotificationEvent.java
+++ b/src/main/java/com/barter/event/trade/TradeNotificationEvent.java
@@ -1,0 +1,11 @@
+package com.barter.event.trade;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TradeNotificationEvent {
+	private final Long tradeId;
+	private final String productName;
+}

--- a/src/main/java/com/barter/event/trade/TradeNotificationEventListener.java
+++ b/src/main/java/com/barter/event/trade/TradeNotificationEventListener.java
@@ -32,6 +32,7 @@ public class TradeNotificationEventListener {
 			.findByFavoriteKeywordIn(existsKeywords);
 		keywordMembers.forEach(member -> {
 			// TODO: 알림 전송 개발되면 추가 예정.
+			log.info("관심 키워드로 등록한 물품 {}이(가) 교환에 등록되었습니다.", event.getProductName());
 		});
 	}
 }

--- a/src/main/java/com/barter/event/trade/TradeNotificationEventListener.java
+++ b/src/main/java/com/barter/event/trade/TradeNotificationEventListener.java
@@ -1,0 +1,37 @@
+package com.barter.event.trade;
+
+import java.util.List;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.barter.common.KeywordHelper;
+import com.barter.domain.member.entity.FavoriteKeyword;
+import com.barter.domain.member.entity.MemberFavoriteKeyword;
+import com.barter.domain.member.repository.FavoriteKeywordRepository;
+import com.barter.domain.member.repository.MemberFavoriteKeywordRepository;
+import com.barter.domain.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "TradeNotificationEventListener")
+@Component
+@RequiredArgsConstructor
+public class TradeNotificationEventListener {
+
+	private final FavoriteKeywordRepository favoriteKeywordRepository;
+	private final MemberFavoriteKeywordRepository memberFavoriteKeywordRepository;
+	private final NotificationService notificationService;
+
+	@EventListener
+	public void sendNotificationToMember(TradeNotificationEvent event) {
+		List<String> keywords = KeywordHelper.extractKeywords(event.getProductName());
+		List<FavoriteKeyword> existsKeywords = favoriteKeywordRepository.findByKeywordIn(keywords);
+		List<MemberFavoriteKeyword> keywordMembers = memberFavoriteKeywordRepository
+			.findByFavoriteKeywordIn(existsKeywords);
+		keywordMembers.forEach(member -> {
+			// TODO: 알림 전송 개발되면 추가 예정.
+		});
+	}
+}


### PR DESCRIPTION
## 개요
- 교환이 등록될 때 해당 교환 물품의 키워드를 관심 키워드로 등록한 유저들에게 알림 전송 기능
- 알림 기능은 상진님이 개발 완료 후 적용하시기로 정함
- 현재는 나눔 교환쪽에만 적용함
- 추후 교환들의 부모 클래스가 나오면 도메인 이벤트로 교체해서 엔티티가 생성할 때 이벤트 발행되도록 수정하면 좋을 것 같음

    Resolves: #122 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제