### PR TITLE
[FEAT] 알림 상태 수정 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/barter/domain/notification/controller/NotificationController.java
@@ -7,15 +7,19 @@ import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import com.barter.domain.notification.dto.request.UpdateNotificationStatusReqDto;
 import com.barter.domain.notification.dto.response.FindNotificationResDto;
 import com.barter.domain.notification.service.NotificationService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -44,5 +48,14 @@ public class NotificationController {
 		// 인증/인가 파트 구현이 끝난다면, 'NOTIFICATIONS' 테이블에서 요청 회원의 활동 알림들을 조회하도록 할 것 같습니다.
 
 		return notificationService.findActivityNotifications(pageable);
+	}
+
+	@PatchMapping("/status")
+	@ResponseStatus(HttpStatus.OK)
+	public void updateNotificationStatus(@RequestBody @Valid UpdateNotificationStatusReqDto request) {
+		// 인증/인가 파트 구현이 끝난다면, RequestBody 가 아닌 HttpRequestServlet 을 통해 검증 회원 정보를 전달 받을 것 같습니다.
+		// RequestBody 의 'notificationId' 는 path parameter 로 전달받을 생각입니다.
+
+		notificationService.updateNotificationStatus(request);
 	}
 }

--- a/src/main/java/com/barter/domain/notification/dto/request/UpdateNotificationStatusReqDto.java
+++ b/src/main/java/com/barter/domain/notification/dto/request/UpdateNotificationStatusReqDto.java
@@ -1,0 +1,15 @@
+package com.barter.domain.notification.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+// 인증/인가를 반영하면 해당 DTO 는 사용하지 않기에 삭제할 계획입니다.
+@Getter
+public class UpdateNotificationStatusReqDto {
+
+	@NotNull
+	private Long notificationId;
+
+	@NotNull
+	private Long memberId;
+}

--- a/src/main/java/com/barter/domain/notification/entity/Notification.java
+++ b/src/main/java/com/barter/domain/notification/entity/Notification.java
@@ -72,4 +72,8 @@ public class Notification extends BaseTimeStampEntity {
 			.memberId(memberId)
 			.build();
 	}
+
+	public void updateStatus() {
+		this.isRead = true;
+	}
 }

--- a/src/main/java/com/barter/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/barter/domain/notification/service/NotificationService.java
@@ -1,13 +1,18 @@
 package com.barter.domain.notification.service;
 
+import java.util.Objects;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.barter.domain.notification.SseEmitters;
+import com.barter.domain.notification.dto.request.UpdateNotificationStatusReqDto;
 import com.barter.domain.notification.dto.response.FindNotificationResDto;
+import com.barter.domain.notification.entity.Notification;
 import com.barter.domain.notification.respository.NotificationRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -46,5 +51,19 @@ public class NotificationService {
 			.map(FindNotificationResDto::from);
 
 		return new PagedModel<>(foundNotifications);
+	}
+
+	// 인증/인가 구현되면 RequestBody 가 아닌 파라미터로 전달된 요청 회원 정보로 알림 대상인지 확인할 계획입니다.
+	@Transactional
+	public void updateNotificationStatus(UpdateNotificationStatusReqDto request) {
+		Notification foundNotification = notificationRepository.findById(request.getNotificationId())
+			.orElseThrow(() -> new IllegalArgumentException("Notification not found"));
+
+		if (!Objects.equals(foundNotification.getMemberId(), request.getMemberId())) {
+			throw new IllegalArgumentException("수정 권한이 없습니다.");
+		}
+
+		foundNotification.updateStatus();
+		notificationRepository.save(foundNotification);
 	}
 }


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
DB 의 알림 정보 상태(=사용자 조회 여부)를 `읽지 않음 → 읽음` 으로 수정하는 기능을 구현하였습니다.
- 기능 구현에 반영한 요구사항 및 예외처리 내용은 아래의 이슈를 통해 확인하실 수 있습니다.

Resolves: #132 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제