### PR TITLE
[FEAT] 기간 교환 자동 마감 업데이트 구현

### DIFF
--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -75,8 +75,8 @@ public class PeriodTradeController {
 	}
 
 	@DeleteMapping("/period-trades/{id}")
-	public ResponseEntity<Void> deletePeriodTrade(@PathVariable Long id) {
-		periodTradeService.deletePeriodTrade(id);
+	public ResponseEntity<Void> deletePeriodTrade(Member member, @PathVariable Long id) {
+		periodTradeService.deletePeriodTrade(member, id);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -82,10 +82,11 @@ public class PeriodTradeController {
 
 	@PostMapping("/period-trades/{id}/suggest") // 등록된 기간 교환에 대한 타 유저의 제안 요청 (최대 제안 물품은 일단 3개)
 	public ResponseEntity<SuggestedPeriodTradeResDto> suggestPeriodTrade(
+		Member member,
 		@PathVariable Long id,
 		@Valid @RequestBody SuggestedPeriodTradeReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(
-			periodTradeService.suggestPeriodTrade(id, reqDto)
+			periodTradeService.suggestPeriodTrade(member, id, reqDto)
 		);
 	}
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -92,11 +92,12 @@ public class PeriodTradeController {
 
 	@PatchMapping("/period-trades/{id}/status")
 	public ResponseEntity<StatusUpdateResDto> updatePeriodTradeStatus(
+		Member member,
 		@PathVariable Long id,
 		@Valid @RequestBody StatusUpdateReqDto reqDto
 	) {
 		return ResponseEntity.status(HttpStatus.OK).body(
-			periodTradeService.updatePeriodTradeStatus(id, reqDto)
+			periodTradeService.updatePeriodTradeStatus(member, id, reqDto)
 		);
 
 	}

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -104,19 +104,21 @@ public class PeriodTradeController {
 
 	@PatchMapping("/period-trades/{id}/acceptance")
 	public ResponseEntity<AcceptPeriodTradeResDto> acceptPeriodTrade(
+		Member member,
 		@PathVariable Long id,
 		@Valid @RequestBody AcceptPeriodTradeReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(
-			periodTradeService.acceptPeriodTrade(id, reqDto)
+			periodTradeService.acceptPeriodTrade(member, id, reqDto)
 		);
 	}
 
 	@PatchMapping("/period-trades/{id}/denial")
 	public ResponseEntity<DenyPeriodTradeResDto> denyPeriodTrade(
+		Member member,
 		@PathVariable Long id,
 		@Valid @RequestBody DenyPeriodTradeReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(
-			periodTradeService.denyPeriodTrade(id, reqDto)
+			periodTradeService.denyPeriodTrade(member, id, reqDto)
 		);
 	}
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -46,7 +46,7 @@ public class PeriodTradeController {
 	public ResponseEntity<CreatePeriodTradeResDto> createPeriodTrades(
 		Member member,
 		@Valid @RequestBody CreatePeriodTradeReqDto reqDto) {
-		return ResponseEntity.status(HttpStatus.CREATED).body(periodTradeService.createPeriodTrades(member, reqDto));
+		return ResponseEntity.status(HttpStatus.CREATED).body(periodTradeService.createPeriodTrades(reqDto));
 	}
 
 	@GetMapping("/period-trades")

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.barter.domain.member.entity.Member;
 import com.barter.domain.trade.periodtrade.dto.request.AcceptPeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.CreatePeriodTradeReqDto;
 import com.barter.domain.trade.periodtrade.dto.request.DenyPeriodTradeReqDto;
@@ -38,11 +39,14 @@ public class PeriodTradeController {
 	private final PeriodTradeService periodTradeService;
 
 	// TODO : 아래 모든 컨트롤러에 유저 정보가 포함되어야 한다.
+	// VerifiedMember member 형식으로 유저 정보가들어올 예정 (정보 : id, email, nickname)
+	// 일단 Member 로 하자
 
 	@PostMapping("/period-trades")
 	public ResponseEntity<CreatePeriodTradeResDto> createPeriodTrades(
+		Member member,
 		@Valid @RequestBody CreatePeriodTradeReqDto reqDto) {
-		return ResponseEntity.status(HttpStatus.CREATED).body(periodTradeService.createPeriodTrades(reqDto));
+		return ResponseEntity.status(HttpStatus.CREATED).body(periodTradeService.createPeriodTrades(member, reqDto));
 	}
 
 	@GetMapping("/period-trades")

--- a/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/controller/PeriodTradeController.java
@@ -66,10 +66,11 @@ public class PeriodTradeController {
 
 	@PatchMapping("/period-trades/{id}")
 	public ResponseEntity<UpdatePeriodTradeResDto> updatePeriodTrade(
+		Member member,
 		@PathVariable Long id,
 		@Valid @RequestBody UpdatePeriodTradeReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.OK).body(
-			periodTradeService.updatePeriodTrade(id, reqDto)
+			periodTradeService.updatePeriodTrade(member, id, reqDto)
 		);
 	}
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/dto/request/CreatePeriodTradeReqDto.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/dto/request/CreatePeriodTradeReqDto.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @Getter
 public class CreatePeriodTradeReqDto {
 
+	private Long memberId;
 	@NotBlank(message = "타이틀은 필수입니다.")
 	@Size(min = 5, message = "타이틀은 5글자 이상이어야 합니다.")
 	private String title;

--- a/src/main/java/com/barter/domain/trade/periodtrade/entity/PeriodTrade.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/entity/PeriodTrade.java
@@ -70,6 +70,11 @@ public class PeriodTrade extends BaseTimeStampEntity {
 		if (endedAt.minusDays(MAX_AFTER_DAY).isAfter(LocalDateTime.now())) {
 			throw new IllegalArgumentException("종료일자는 오늘로부터 7일 이내만 가능합니다.");
 		}
+		if (endedAt.isBefore(LocalDateTime.now())) {
+			throw new IllegalArgumentException("현재 시간보다 적은 시간 예약은 불가능 합니다.");
+		}
+
+		// 추가 : 혹시 최소 마감 시간을 정해두면 그것을 여기에 적용하면 좋을 것 같습니다.
 	}
 
 	public void addViewCount() {

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -67,8 +67,6 @@ public class PeriodTradeService {
 		return CreatePeriodTradeResDto.from(periodTradeRepository.save(periodTrade));
 	}
 
-	// TODO : (PeriodTrade 조회) : 멤버 구현 시 멤버정보를 받아서 해당 멤버가 참여한 PeriodTrade 만 조회 가능하도록 하기
-
 	@Transactional(readOnly = true)
 	public PagedModel<FindPeriodTradeResDto> findPeriodTrades(Pageable pageable) {
 		Page<FindPeriodTradeResDto> trades = periodTradeRepository.findAll(pageable)
@@ -102,13 +100,13 @@ public class PeriodTradeService {
 	}
 
 	@Transactional
-	public void deletePeriodTrade(Long id) {
-		Long userId = 1L;
+	public void deletePeriodTrade(Member member, Long id) {
+
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
 
-		periodTrade.validateAuthority(userId);
+		periodTrade.validateAuthority(member.getId());
 		periodTrade.validateIsCompleted();
 		periodTradeRepository.delete(periodTrade);
 

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -139,14 +139,13 @@ public class PeriodTradeService {
 	}
 
 	@Transactional
-	public StatusUpdateResDto updatePeriodTradeStatus(Long id, StatusUpdateReqDto reqDto) {
-		Long userId = 1L;
+	public StatusUpdateResDto updatePeriodTradeStatus(Member member, Long id, StatusUpdateReqDto reqDto) {
 
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
 
-		periodTrade.validateAuthority(userId); // 교환 (게시글)의 주인만 변경 가능
+		periodTrade.validateAuthority(member.getId()); // 교환 (게시글)의 주인만 변경 가능
 		periodTrade.validateIsCompleted(); // 이미 완료된 교환 건은 수정 불가
 		boolean isStatusUpdatable = periodTrade.updatePeriodTradeStatus(reqDto.getTradeStatus());
 		if (!isStatusUpdatable) {

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -158,14 +158,12 @@ public class PeriodTradeService {
 	}
 
 	@Transactional
-	public AcceptPeriodTradeResDto acceptPeriodTrade(Long id, AcceptPeriodTradeReqDto reqDto) {
-
-		Long userId = 1L;
+	public AcceptPeriodTradeResDto acceptPeriodTrade(Member member, Long id, AcceptPeriodTradeReqDto reqDto) {
 
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
-		periodTrade.validateAuthority(userId);
+		periodTrade.validateAuthority(member.getId());
 		periodTrade.validateInProgress();
 
 		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(id, TradeType.PERIOD);
@@ -191,13 +189,12 @@ public class PeriodTradeService {
 
 	// TODO : Deny 부분이 Accept 랑 구조가 비슷해서 단순화 시킬 필요 있다.
 	@Transactional
-	public DenyPeriodTradeResDto denyPeriodTrade(Long id, DenyPeriodTradeReqDto reqDto) {
-		Long userId = 1L;
+	public DenyPeriodTradeResDto denyPeriodTrade(Member member, Long id, DenyPeriodTradeReqDto reqDto) {
 
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
-		periodTrade.validateAuthority(userId);
+		periodTrade.validateAuthority(member.getId());
 		periodTrade.validateInProgress();
 
 		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(id, TradeType.PERIOD);

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -52,14 +52,14 @@ public class PeriodTradeService {
 
 	// TODO : Member 는 나중에 VerifiedMember 로 변경될 예정
 	@Transactional
-	public CreatePeriodTradeResDto createPeriodTrades(Member member, CreatePeriodTradeReqDto reqDto) {
+	public CreatePeriodTradeResDto createPeriodTrades(CreatePeriodTradeReqDto reqDto) {
 
 		RegisteredProduct registeredProduct = registeredProductRepository.findById(reqDto.getRegisteredProductId())
 			.orElseThrow(
 				() -> new IllegalArgumentException("없는 등록된 물건입니다.")
 			);
 
-		registeredProduct.validateOwner(member.getId());
+		registeredProduct.validateOwner(reqDto.getMemberId());
 
 		PeriodTrade periodTrade = PeriodTrade.createInitPeriodTrade(reqDto.getTitle(), reqDto.getDescription(),
 			registeredProduct,

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -1,7 +1,6 @@
 package com.barter.domain.trade.periodtrade.service;
 
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -57,9 +56,7 @@ public class PeriodTradeService {
 				() -> new IllegalArgumentException("없는 등록된 물건입니다.")
 			);
 
-		if (!Objects.equals(registeredProduct.getMember().getId(), member.getId())) {
-			throw new IllegalArgumentException("해당 물건 등록에 대한 권한이 없습니다.");
-		}
+		registeredProduct.validateOwner(member.getId());
 
 		PeriodTrade periodTrade = PeriodTrade.createInitPeriodTrade(reqDto.getTitle(), reqDto.getDescription(),
 			registeredProduct,

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -113,14 +113,13 @@ public class PeriodTradeService {
 	}
 
 	@Transactional
-	public SuggestedPeriodTradeResDto suggestPeriodTrade(Long id, SuggestedPeriodTradeReqDto reqDto) {
+	public SuggestedPeriodTradeResDto suggestPeriodTrade(Member member, Long id, SuggestedPeriodTradeReqDto reqDto) {
 
-		Long userId = 2L; // 게시글에 제안하는 멤버
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
 
-		periodTrade.validateSuggestAuthority(userId); // 자신의 교환 (게시글) 에 제안 불가
+		periodTrade.validateSuggestAuthority(member.getId()); // 자신의 교환 (게시글) 에 제안 불가
 
 		// 기간 교환 시작 전(PENDING) 또는 이미 거래된(COMPLETED) 교환인 경우
 		periodTrade.validateIsPending();

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -1,6 +1,7 @@
 package com.barter.domain.trade.periodtrade.service;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,6 +9,7 @@ import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.barter.domain.member.entity.Member;
 import com.barter.domain.member.repository.MemberRepository;
 import com.barter.domain.product.entity.RegisteredProduct;
 import com.barter.domain.product.entity.SuggestedProduct;
@@ -47,14 +49,17 @@ public class PeriodTradeService {
 	private final MemberRepository memberRepository;
 	private final TradeProductRepository tradeProductRepository;
 
-	public CreatePeriodTradeResDto createPeriodTrades(CreatePeriodTradeReqDto reqDto) {
+	// TODO : Member 는 나중에 VerifiedMember 로 변경될 예정
+	public CreatePeriodTradeResDto createPeriodTrades(Member member, CreatePeriodTradeReqDto reqDto) {
 
-		/* TODO : RegisteredProduct 가 해당 유저의 물건인지 확인하는 로직 필요
-		    해당 로직 추가시 아래 코드는 변경 될 수 있음*/
 		RegisteredProduct registeredProduct = registeredProductRepository.findById(reqDto.getRegisteredProductId())
 			.orElseThrow(
 				() -> new IllegalArgumentException("없는 등록된 물건입니다.")
 			);
+
+		if (!Objects.equals(registeredProduct.getMember().getId(), member.getId())) {
+			throw new IllegalArgumentException("해당 물건 등록에 대한 권한이 없습니다.");
+		}
 
 		PeriodTrade periodTrade = PeriodTrade.createInitPeriodTrade(reqDto.getTitle(), reqDto.getDescription(),
 			registeredProduct,

--- a/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/service/PeriodTradeService.java
@@ -88,17 +88,16 @@ public class PeriodTradeService {
 	}
 
 	@Transactional
-	public UpdatePeriodTradeResDto updatePeriodTrade(Long id, UpdatePeriodTradeReqDto reqDto) {
+	public UpdatePeriodTradeResDto updatePeriodTrade(Member member, Long id, UpdatePeriodTradeReqDto reqDto) {
 
-		Long userId = 1L;
 		PeriodTrade periodTrade = periodTradeRepository.findById(id).orElseThrow(
 			() -> new IllegalArgumentException("해당하는 기간 거래를 찾을 수 없습니다.")
 		);
-		periodTrade.validateAuthority(userId);
+		periodTrade.validateAuthority(member.getId());
 		periodTrade.validateIsCompleted();
 		periodTrade.update(reqDto.getTitle(), reqDto.getDescription());
 
-		return UpdatePeriodTradeResDto.from(periodTrade); // save 써도 되고 안써도 되고
+		return UpdatePeriodTradeResDto.from(periodTrade);
 
 	}
 

--- a/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEvent.java
+++ b/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEvent.java
@@ -1,0 +1,15 @@
+package com.barter.event.trade.PeriodTradeEvent;
+
+import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
+
+import lombok.Getter;
+
+@Getter
+public class PeriodTradeCloseEvent {
+	private final PeriodTrade periodTrade;
+
+	public PeriodTradeCloseEvent(PeriodTrade periodTrade) {
+		this.periodTrade = periodTrade;
+	}
+
+}

--- a/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
+++ b/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
@@ -27,7 +27,7 @@ public class PeriodTradeCloseEventListener {
 
 	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void addPeriodTradeCloseEvent(PeriodTradeCloseEvent event) {
+	public void createPeriodTradeCloseEvent(PeriodTradeCloseEvent event) {
 		PeriodTrade periodTrade = event.getPeriodTrade();
 		updatePeriodTradeClosed(periodTrade);
 	}

--- a/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
+++ b/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
@@ -1,0 +1,47 @@
+package com.barter.event.trade.PeriodTradeEvent;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.barter.domain.trade.enums.TradeStatus;
+import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "기간 교환 마감 이벤트 ")
+@Component
+@RequiredArgsConstructor
+public class PeriodTradeCloseEventListener {
+
+	private final TaskScheduler taskScheduler;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void addPeriodTradeCloseEvent(PeriodTradeCloseEvent event) {
+		PeriodTrade periodTrade = event.getPeriodTrade();
+		updatePeriodTradeClosed(periodTrade);
+	}
+
+	private void updatePeriodTradeClosed(PeriodTrade periodTrade) {
+		Long periodTradeId = periodTrade.getId();
+		Instant closeTime = toInstant(periodTrade.getEndedAt());
+		log.info("기간 교환 마감 시간 스케줄링, PeriodTradeId : {} , closeTime : {}", periodTradeId, closeTime);
+		taskScheduler.schedule(() ->
+			{
+				periodTrade.updatePeriodTradeStatus(TradeStatus.CLOSED);
+				log.info("기간 교환 상태가 CLOSED 로 변경되었습니다. PeriodTradeId: {}", periodTradeId);
+			},
+			closeTime);
+	}
+
+	private Instant toInstant(LocalDateTime localDateTime) {
+		return localDateTime.atZone(Clock.systemDefaultZone().getZone()).toInstant();
+	} // 현재 시스템의 기본 시간대로 설정
+
+}

--- a/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
+++ b/src/main/java/com/barter/event/trade/PeriodTradeEvent/PeriodTradeCloseEventListener.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -24,6 +25,7 @@ public class PeriodTradeCloseEventListener {
 	private final TaskScheduler taskScheduler;
 	private final PeriodTradeRepository periodTradeRepository; // 추가된 부분
 
+	@Async
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void addPeriodTradeCloseEvent(PeriodTradeCloseEvent event) {
 		PeriodTrade periodTrade = event.getPeriodTrade();


### PR DESCRIPTION
## 개요

1. 기간 교환 마감 시간이 지나면 TaskScheduler 를 이용하여 해당 교환이 자동으로 CLOSED 되도록함
2. 기간 교환을 등록 시에 마감시간에 대한 이벤트를 생성하고 해당 이벤트를 발생시킨다.
3. 기간 교환 등록 시 마감시간이 현재시간보다 이전인 경우 예외 발생 추가 (추후 최소 마감시간 기간을 정할 필요 있음)
4. 기간 교환 생성 제외 나머지 기간 교환 api 에 인증된 member 가 왔다고 가정하고 적용완료

Resolves: #129 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제