### PR TITLE
Feat : 채팅 방 생성 로직 수정 및 채팅 서버 접속 시 jwt 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,11 @@ dependencies {
 
     // s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    // STOMP
+    implementation 'org.webjars:stomp-websocket:2.3.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/barter/config/WebSocketConfig.java
+++ b/src/main/java/com/barter/config/WebSocketConfig.java
@@ -1,17 +1,25 @@
 package com.barter.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import com.barter.domain.chat.interceptor.AuthChannelInterceptor;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+	
+	private final AuthChannelInterceptor authChannelInterceptor;
+
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 
@@ -29,5 +37,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 		registry.addEndpoint("/ws")
 			.setAllowedOrigins("*");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(authChannelInterceptor);
 	}
 }

--- a/src/main/java/com/barter/config/WebSocketConfig.java
+++ b/src/main/java/com/barter/config/WebSocketConfig.java
@@ -1,0 +1,33 @@
+package com.barter.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+
+		// 메시지 구독 url (topic 구독)
+		registry.enableSimpleBroker("/topic");
+
+		// 메시지 발행 url, @MessageMapping 어노테이션과 연결됨
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+
+		// 웹소켓 (STOMP)  접속 주소 설정
+
+		registry.addEndpoint("/ws")
+			.setAllowedOrigins("*");
+	}
+}

--- a/src/main/java/com/barter/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatController.java
@@ -1,0 +1,25 @@
+package com.barter.domain.chat.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class ChatController {
+
+	private final SimpMessageSendingOperations template;
+
+	@MessageMapping("/enter-user")
+	public void enterUser(SimpMessageHeaderAccessor headerAccessor) {
+
+		System.out.println("userId = " + headerAccessor.getHeader("simpSessionAttributes"));
+
+		template.convertAndSend("/topic/chat/room", "hello everyOne");
+	}
+}

--- a/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
@@ -7,10 +7,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.chat.dto.request.CreateChatRoomReqDto;
 import com.barter.domain.chat.dto.response.CreateChatRoomResDto;
 import com.barter.domain.chat.service.ChatRoomService;
-import com.barter.domain.member.entity.Member;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,8 +22,7 @@ public class ChatRoomController {
 	private final ChatRoomService chatRoomService;
 
 	@PostMapping
-	// 일단 member 를 가져왔습니다. (현재 인증된 멤버에 대한 정보 : id, email, nickname)
-	public ResponseEntity<CreateChatRoomResDto> createChatRoom(Member member,
+	public ResponseEntity<CreateChatRoomResDto> createChatRoom(VerifiedMember member,
 		@RequestBody CreateChatRoomReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.CREATED).body(chatRoomService.createChatRoom(member, reqDto));
 	}

--- a/src/main/java/com/barter/domain/chat/dto/response/CreateChatRoomResDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/response/CreateChatRoomResDto.java
@@ -3,6 +3,7 @@ package com.barter.domain.chat.dto.response;
 import java.time.LocalDateTime;
 
 import com.barter.domain.chat.entity.ChatRoom;
+import com.barter.domain.chat.enums.RoomStatus;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ public class CreateChatRoomResDto {
 	private String roomId;
 	private String suggestMemberNickname;
 	private String registerMemberNickname;
+	private RoomStatus roomStatus;
 	private LocalDateTime createdAt;
 
 	public static CreateChatRoomResDto of(ChatRoom chatRoom, String suggestMemberNickname,
@@ -23,6 +25,7 @@ public class CreateChatRoomResDto {
 			.suggestMemberNickname(suggestMemberNickname)
 			.registerMemberNickname(registerMemberNickname)
 			.createdAt(LocalDateTime.now())
+			.roomStatus(chatRoom.getRoomStatus())
 			.build();
 	}
 }

--- a/src/main/java/com/barter/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/com/barter/domain/chat/entity/ChatRoom.java
@@ -3,7 +3,11 @@ package com.barter.domain.chat.entity;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.barter.domain.chat.enums.RoomStatus;
+
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -25,10 +29,17 @@ public class ChatRoom {
 
 	private LocalDateTime createdAt;
 
+	private Long personCount; // 추후 확장성 고려
+
+	@Enumerated(EnumType.STRING)
+	private RoomStatus roomStatus;
+
 	public static ChatRoom create() {
 		return ChatRoom.builder()
 			.id(UUID.randomUUID().toString())
 			.createdAt(LocalDateTime.now())
+			.personCount(2L)
+			.roomStatus(RoomStatus.OPEN)
 			.build();
 	}
 

--- a/src/main/java/com/barter/domain/chat/entity/ChatRoomMember.java
+++ b/src/main/java/com/barter/domain/chat/entity/ChatRoomMember.java
@@ -4,6 +4,8 @@ import com.barter.domain.member.entity.Member;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,6 +24,7 @@ import lombok.NoArgsConstructor;
 public class ChatRoomMember {
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/barter/domain/chat/enums/RoomStatus.java
+++ b/src/main/java/com/barter/domain/chat/enums/RoomStatus.java
@@ -1,0 +1,8 @@
+package com.barter.domain.chat.enums;
+
+public enum RoomStatus {
+	OPEN,
+	IN_PROGRESS,
+	CLOSED
+
+}

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -29,6 +29,10 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 			log.info("accessor Headers :{}", accessor.getMessageHeaders());
 			log.info("Auth token: {}", authToken);
 			jwtUtil.validateToken(authToken);
+
+			String userId = jwtUtil.getMemberClaims(authToken).getSubject();
+			log.info("userId: {}", userId);
+
 		}
 
 		// 추가로 SUBSCRIBE, DISCONNECT 와 같은 로직도 여기서 구현 가능하다.

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -1,0 +1,38 @@
+package com.barter.domain.chat.interceptor;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import com.barter.security.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthChannelInterceptor implements ChannelInterceptor {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+		if (StompCommand.CONNECT == accessor.getCommand()) {
+			// 연결 시 인증
+			String authToken = accessor.getFirstNativeHeader("Authorization");
+			log.info("accessor Headers :{}", accessor.getMessageHeaders());
+			log.info("Auth token: {}", authToken);
+			jwtUtil.validateToken(authToken);
+		}
+
+		// 추가로 SUBSCRIBE, DISCONNECT 와 같은 로직도 여기서 구현 가능하다.
+
+		return message;
+	}
+}

--- a/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
@@ -3,6 +3,7 @@ package com.barter.domain.chat.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.chat.dto.request.CreateChatRoomReqDto;
 import com.barter.domain.chat.dto.response.CreateChatRoomResDto;
 import com.barter.domain.chat.entity.ChatRoom;
@@ -26,9 +27,12 @@ public class ChatRoomService {
 	// 현재는 방 생성과 동시에 1명의 유저가 초대 되는 느낌이어서 아래와 같이 표현 하였습니다.
 	// 만약 방을 생성하고 유저를 초대하는 방식이라면 api 가 분리될 필요가 있다고 봅니다.
 	@Transactional
-	public CreateChatRoomResDto createChatRoom(Member member, CreateChatRoomReqDto reqDto) {
+	public CreateChatRoomResDto createChatRoom(VerifiedMember member, CreateChatRoomReqDto reqDto) {
 
 		Member registerMember = memberRepository.findById(reqDto.getRegisterMemberId())
+			.orElseThrow(() -> new IllegalArgumentException("해당하는 멤버가 없습니다."));
+
+		Member suggestMember = memberRepository.findById(member.getId())
 			.orElseThrow(() -> new IllegalArgumentException("해당하는 멤버가 없습니다."));
 
 		// 채팅방 생성
@@ -36,7 +40,7 @@ public class ChatRoomService {
 		chatRoomRepository.save(chatRoom);
 
 		// suggestMember 저장
-		ChatRoomMember memberChatRoomMember = ChatRoomMember.create(member, chatRoom);
+		ChatRoomMember memberChatRoomMember = ChatRoomMember.create(suggestMember, chatRoom);
 
 		chatRoomMemberRepository.save(memberChatRoomMember);
 
@@ -45,7 +49,7 @@ public class ChatRoomService {
 
 		chatRoomMemberRepository.save(sellerRoomMember);
 
-		return CreateChatRoomResDto.of(chatRoom, member.getNickname(), registerMember.getNickname());
+		return CreateChatRoomResDto.of(chatRoom, suggestMember.getNickname(), registerMember.getNickname());
 
 	}
 }

--- a/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
@@ -35,6 +35,10 @@ public class ChatRoomService {
 		Member suggestMember = memberRepository.findById(member.getId())
 			.orElseThrow(() -> new IllegalArgumentException("해당하는 멤버가 없습니다."));
 
+		if (registerMember.equals(suggestMember)) {
+			throw new IllegalArgumentException("자기 자신을 초대할 수는 없습니다.");
+		}
+
 		// 채팅방 생성
 		ChatRoom chatRoom = ChatRoom.create();
 		chatRoomRepository.save(chatRoom);


### PR DESCRIPTION
## 개요

- [x] 채팅 서버에 CONNECT 하기 전에 jwt 토큰의 유효성 검증 (인증된 사용자만 채팅 서버 접속 가능하도록)
- [x] AuthChannelInterceptor 를 통해 해당 유저의 토큰 검증 후 userId 추출 (추후에 중복 세션 관리 및 허가된 채팅 방 입장을 위함)
- [x] WebSocket 연결 테스트를 위한 ChatController 간단 구현 (추후 수정 예정) - ChatController
- [x] ChatRoomMember 엔티티 id Generate Type 추가 (기존에 없었던 것 수정)
- [x] 채팅방 생성에 기존 부재했던 인증인가 (verifiedMember) 기능 추가 및 코드 수정
- [x] 채팅방에 자기 자신 초대하는 것에 대한 예외처리 추가
- [x] ChatRoom 엔티티에 현재 인원 수 및 채팅 상태 column 추가 
(인원수는 추후 확장성 고려, 채팅 상태는 [채팅방 오픈, 채팅 시작, 채팅 종료] 의 3가지)

Resolves: #205 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제