### PR TITLE
[REFACTOR] : 채팅 인터셉터 예외 핸들러로 예외 처리 하도록 수정

### DIFF
--- a/src/main/java/com/barter/config/WebSocketConfig.java
+++ b/src/main/java/com/barter/config/WebSocketConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import com.barter.domain.chat.handler.StompErrorHandler;
 import com.barter.domain.chat.interceptor.AuthChannelInterceptor;
 
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,9 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
-	
+
 	private final AuthChannelInterceptor authChannelInterceptor;
+	private final StompErrorHandler stompErrorHandler;
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -37,6 +39,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 		registry.addEndpoint("/ws")
 			.setAllowedOrigins("*");
+
+		registry.setErrorHandler(stompErrorHandler);
+
 	}
 
 	@Override

--- a/src/main/java/com/barter/domain/chat/handler/StompErrorHandler.java
+++ b/src/main/java/com/barter/domain/chat/handler/StompErrorHandler.java
@@ -1,0 +1,53 @@
+package com.barter.domain.chat.handler;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+		// 예외에 따라 클라이언트에 보낼 커스텀 메시지 생성
+		String errorMessage = "An unexpected error occurred.";
+		Throwable rootCause = ex; // 예외의 루트 원인
+
+		if (ex instanceof MessageDeliveryException) {
+			rootCause = ex.getCause(); // 실제 원인 예외를 추출
+			log.info("Root cause of the error: {}", rootCause.getClass().getName());
+		}
+
+		// IllegalArgumentException 예외 추출
+		if (rootCause instanceof IllegalArgumentException) {
+			log.info("Caught IllegalArgumentException: {}", rootCause.getMessage());
+			errorMessage = "Invalid subscription: " + rootCause.getMessage();
+		} else if (rootCause instanceof IllegalStateException) {
+			log.info("Caught IllegalStateException: {}", rootCause.getMessage());
+			errorMessage = "Server state issue: " + rootCause.getMessage();
+		}
+
+		// STOMP ERROR 메시지 헤더 구성
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+		accessor.setMessage(errorMessage); // 클라이언트가 읽을 기본 메시지
+		accessor.addNativeHeader("error-code", "4001"); // 커스텀 에러 코드 추가 가능
+		accessor.addNativeHeader("error-message", errorMessage); // 상세 메시지 추가
+
+		// TODO : 추후 응답 메시지 정리 할 필요 있음
+
+		log.info("헤더 정보 : {}", accessor);
+
+		// 클라이언트에 보낼 메시지 생성
+		return MessageBuilder.createMessage(
+			errorMessage.getBytes(), // 에러 내용을 바이트 배열로 변환
+			accessor.getMessageHeaders()
+		);
+	}
+}

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -49,15 +49,30 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 			log.info("User {} is subscribing to {}", userId, destination);
 
 			if (destination != null && destination.startsWith("/topic/chat/room")) {
-				System.out.println("이거 실행됨");
 				String roomId = destination.split("/topic/chat/room/")[1];
+				log.info("roomId: {}", roomId);
 
-				chatRoomService.changeRoomStatus(roomId);
-				chatRoomService.updateMemberJoinStatus(roomId, Long.valueOf(userId), JoinStatus.IN_ROOM);
+				try {
+					chatRoomService.changeRoomStatus(roomId);
+					chatRoomService.updateMemberJoinStatus(roomId, Long.valueOf(userId), JoinStatus.IN_ROOM);
+
+				} catch (IllegalArgumentException e) {
+					// log.error("Error occurred while subscribing to room: {}", e.getMessage(), e);
+					// StompHeaderAccessor errorAccessor = StompHeaderAccessor.create(StompCommand.ERROR);
+					// errorAccessor.setMessage("Error: " + e.getMessage());
+					// errorAccessor.addNativeHeader("error", e.getMessage());
+					// log.info("errorAccessor: {}", errorAccessor);
+					// Message<?> errorMessage = MessageBuilder.createMessage("Error: " + e.getMessage(),
+					// 	errorAccessor.getMessageHeaders());
+					// log.info("errorMessage: {}", errorMessage);
+					// 삽 푼 코드
+					throw e;
+				}
 
 			}
 		}
 
+		log.info("message: {}", message);
 		return message;
 	}
 }


### PR DESCRIPTION
## 개요

- [x] StompSubProtocolErrorHandler 를 상속받은 핸들러를 구현
- [x] 해당 핸들러를 등록 후 예외가 발생하면 예외에 대한 정보를 ERROR 커맨드를 가진 StompHeaderAccessor 에 추가하여 클라이언트에 전달

* 참고 이미지
![image](https://github.com/user-attachments/assets/44181ab1-d007-449e-8165-bc03a8c98833)

=> 해당 예외 정보를 클라이언트에 전달 가능 (테스트 툴의 브라우저 console 화면을 캡처한 것)

Resolves: #249 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제