### PR TITLE
[FEAT] 채팅방 나가기 구현 (UNSUBSCRIBE)

### DIFF
--- a/src/main/java/com/barter/config/WebSocketConfig.java
+++ b/src/main/java/com/barter/config/WebSocketConfig.java
@@ -38,7 +38,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		// 웹소켓 (STOMP)  접속 주소 설정
 
 		registry.addEndpoint("/ws")
-			.setAllowedOrigins("*");
+			.setAllowedOrigins("*")
+			.withSockJS(); // js 로 테스트 시
 
 		registry.setErrorHandler(stompErrorHandler);
 

--- a/src/main/java/com/barter/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatController.java
@@ -18,21 +18,6 @@ public class ChatController {
 
 	private final SimpMessageSendingOperations template;
 
-	// @MessageMapping("/enter-user")
-	// public void enterUser(@Payload ChatMessageDto chatMessageDto, SimpMessageHeaderAccessor headerAccessor) {
-	//
-	// 	// chatRoom 상태가 변화해야 한다. (OPEN -> IN_PROGRESS) : 두 명 모두 들어온 경우
-	//
-	// 	String userId = (String)headerAccessor.getSessionAttributes().get("userId");
-	//
-	// 	chatRoomService.changeRoomStatus(chatMessageDto.getRoomId());
-	// 	chatRoomService.updateMemberJoinStatus(chatMessageDto.getRoomId(), Long.valueOf(userId), JoinStatus.IN_ROOM);
-	//
-	// 	// 해당 방의 유저에게 입장을 알림
-	// 	chatMessageDto.setMessage(userId + "님이 입장!");
-	// 	template.convertAndSend("/topic/chat/room/" + chatMessageDto.getRoomId(), chatMessageDto);
-	// }
-
 	@MessageMapping("/send-message")
 	public void sendMessage(@Payload ChatMessageDto chatMessageDto, MessageHeaderAccessor headerAccessor) {
 

--- a/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
@@ -27,8 +27,25 @@ public class ChatRoomEventListener {
 			log.info("멤버 채팅방 구독 성공 : {} 유저가 {} 방에 구독 중", event.getMemberId(), event.getRoomId());
 
 		} catch (Exception e) {
-			log.error("에러 이벤트 발생 : {}", e.getMessage());
+			log.error("구독 에러 이벤트 발생 : {}", e.getMessage());
 			throw e;
 		}
+	}
+
+	@EventListener
+	public void handleUserUnsubscribedEvent(MemberUnsubscribedEvent event) {
+		log.info("멤버 채팅방 구독 취소 >> userId : {}, roomId : {}", event.getMemberId(), event.getRoomId());
+
+		try {
+			chatRoomService.changeRoomStatus(event.getRoomId());
+			chatRoomService.updateMemberJoinStatus(event.getRoomId(), event.getMemberId(), JoinStatus.LEAVE);
+
+			log.info("멤버 채팅방 구독 취소 : {} 유저가 {} 방 구독 취소", event.getMemberId(), event.getRoomId());
+
+		} catch (Exception e) {
+			log.error("구독 취소 에러 이벤트 발생 : {}", e.getMessage());
+			throw e;
+		}
+
 	}
 }

--- a/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
@@ -37,7 +37,6 @@ public class ChatRoomEventListener {
 		log.info("멤버 채팅방 구독 취소 >> userId : {}, roomId : {}", event.getMemberId(), event.getRoomId());
 
 		try {
-			chatRoomService.changeRoomStatus(event.getRoomId());
 			chatRoomService.updateMemberJoinStatus(event.getRoomId(), event.getMemberId(), JoinStatus.LEAVE);
 
 			log.info("멤버 채팅방 구독 취소 : {} 유저가 {} 방 구독 취소", event.getMemberId(), event.getRoomId());

--- a/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
@@ -1,0 +1,34 @@
+package com.barter.domain.chat.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.barter.domain.chat.enums.JoinStatus;
+import com.barter.domain.chat.service.ChatRoomService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatRoomEventListener {
+
+	private final ChatRoomService chatRoomService;
+
+	@EventListener
+	public void handleUserSubscribedEvent(MemberSubscribedEvent event) {
+		log.info("멤버 채팅방 구독 >> userId : {}, roomId : {}", event.getMemberId(), event.getRoomId());
+
+		try {
+			chatRoomService.changeRoomStatus(event.getRoomId());
+			chatRoomService.updateMemberJoinStatus(event.getRoomId(), event.getMemberId(), JoinStatus.IN_ROOM);
+
+			log.info("멤버 채팅방 구독 성공 : {} 유저가 {} 방에 구독 중", event.getMemberId(), event.getRoomId());
+
+		} catch (Exception e) {
+			log.error("에러 이벤트 발생 : {}", e.getMessage());
+			throw e;
+		}
+	}
+}

--- a/src/main/java/com/barter/domain/chat/event/MemberSubscribedEvent.java
+++ b/src/main/java/com/barter/domain/chat/event/MemberSubscribedEvent.java
@@ -1,0 +1,11 @@
+package com.barter.domain.chat.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSubscribedEvent {
+	private final Long memberId;
+	private final String roomId;
+}

--- a/src/main/java/com/barter/domain/chat/event/MemberUnsubscribedEvent.java
+++ b/src/main/java/com/barter/domain/chat/event/MemberUnsubscribedEvent.java
@@ -1,0 +1,11 @@
+package com.barter.domain.chat.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberUnsubscribedEvent {
+	private final Long memberId;
+	private final String roomId;
+}

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -1,5 +1,6 @@
 package com.barter.domain.chat.interceptor;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -7,7 +8,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
-import com.barter.domain.chat.enums.JoinStatus;
+import com.barter.domain.chat.event.MemberSubscribedEvent;
 import com.barter.domain.chat.service.ChatRoomService;
 import com.barter.security.JwtUtil;
 
@@ -21,6 +22,7 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 
 	private final JwtUtil jwtUtil;
 	private final ChatRoomService chatRoomService;
+	private final ApplicationEventPublisher eventPublisher;
 	//private final SimpMessagingTemplate template;
 
 	@Override
@@ -52,22 +54,7 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 				String roomId = destination.split("/topic/chat/room/")[1];
 				log.info("roomId: {}", roomId);
 
-				try {
-					chatRoomService.changeRoomStatus(roomId);
-					chatRoomService.updateMemberJoinStatus(roomId, Long.valueOf(userId), JoinStatus.IN_ROOM);
-
-				} catch (IllegalArgumentException e) {
-					// log.error("Error occurred while subscribing to room: {}", e.getMessage(), e);
-					// StompHeaderAccessor errorAccessor = StompHeaderAccessor.create(StompCommand.ERROR);
-					// errorAccessor.setMessage("Error: " + e.getMessage());
-					// errorAccessor.addNativeHeader("error", e.getMessage());
-					// log.info("errorAccessor: {}", errorAccessor);
-					// Message<?> errorMessage = MessageBuilder.createMessage("Error: " + e.getMessage(),
-					// 	errorAccessor.getMessageHeaders());
-					// log.info("errorMessage: {}", errorMessage);
-					// 삽 푼 코드
-					throw e;
-				}
+				eventPublisher.publishEvent(new MemberSubscribedEvent(Long.valueOf(userId), roomId));
 
 			}
 		}

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
 
 import com.barter.domain.chat.event.MemberSubscribedEvent;
+import com.barter.domain.chat.event.MemberUnsubscribedEvent;
 import com.barter.domain.chat.service.ChatRoomService;
 import com.barter.security.JwtUtil;
 
@@ -52,11 +53,27 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 
 			if (destination != null && destination.startsWith("/topic/chat/room")) {
 				String roomId = destination.split("/topic/chat/room/")[1];
-				log.info("roomId: {}", roomId);
+				log.info("subscribed roomId: {}", roomId);
 
 				eventPublisher.publishEvent(new MemberSubscribedEvent(Long.valueOf(userId), roomId));
 
 			}
+		}
+
+		if (StompCommand.UNSUBSCRIBE == accessor.getCommand()) {
+			String destination = accessor.getDestination();
+			String userId = (String)accessor.getSessionAttributes().get("userId");
+
+			log.info("User {} is unsubscribing from {}", userId, destination);
+
+			if (destination != null && destination.startsWith("/topic/chat/room")) {
+				String roomId = destination.split("/topic/chat/room/")[1];
+				log.info("unsubscribed roomId: {}", roomId);
+
+				eventPublisher.publishEvent(new MemberUnsubscribedEvent(Long.valueOf(userId), roomId));
+
+			}
+
 		}
 
 		log.info("message: {}", message);

--- a/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
+++ b/src/main/java/com/barter/domain/chat/interceptor/AuthChannelInterceptor.java
@@ -47,6 +47,7 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 		// SUBSCRIBE 처리
 		if (StompCommand.SUBSCRIBE == accessor.getCommand()) {
 			String destination = accessor.getDestination();
+			log.info("accessor:{}", accessor);
 			String userId = (String)accessor.getSessionAttributes().get("userId");
 
 			log.info("User {} is subscribing to {}", userId, destination);
@@ -55,21 +56,24 @@ public class AuthChannelInterceptor implements ChannelInterceptor {
 				String roomId = destination.split("/topic/chat/room/")[1];
 				log.info("subscribed roomId: {}", roomId);
 
+				accessor.getSessionAttributes().put("roomId", roomId);
+
 				eventPublisher.publishEvent(new MemberSubscribedEvent(Long.valueOf(userId), roomId));
 
 			}
 		}
 
 		if (StompCommand.UNSUBSCRIBE == accessor.getCommand()) {
-			String destination = accessor.getDestination();
+			String subscriptionId = accessor.getSubscriptionId();
+			log.info("accessor:{}", subscriptionId);
 			String userId = (String)accessor.getSessionAttributes().get("userId");
 
-			log.info("User {} is unsubscribing from {}", userId, destination);
+			log.info("User {} is unsubscribing from {}", userId, subscriptionId);
+			String roomId = (String)accessor.getSessionAttributes().get("roomId");
+			log.info("roomId: {}", roomId);
 
-			if (destination != null && destination.startsWith("/topic/chat/room")) {
-				String roomId = destination.split("/topic/chat/room/")[1];
+			if (subscriptionId != null && subscriptionId.startsWith("sub-")) {
 				log.info("unsubscribed roomId: {}", roomId);
-
 				eventPublisher.publishEvent(new MemberUnsubscribedEvent(Long.valueOf(userId), roomId));
 
 			}


### PR DESCRIPTION
## 개요

- [x] 1:1 채팅방에서 한 명의 멤버가 구독취소 (UNSUBSCRIBE) 요청을 하게 되면 해당 방은 무조건 CLOSED 되도록 함
- [x] 이후 다른 멤버가 해당 방을 구독을 하려고 하면 해당 멤버는 방에서 나간 LEAVE 상태가 되며 ERROR 를 발생시킴
- [x] 기존 인터셉터에서 체크하던 비즈니스로직을 이벤트리스너를 통해 분리 및 구현 함

 Resolves: #242 

* 예시 이미지

1) 닫힌 방 구독 시도 시 예외
![image](https://github.com/user-attachments/assets/7e1dae72-43fb-42f2-b474-19795ce0d5da)

2) 구독 취소 과정 예시 (js 코드로 형식 상, 구독 하자마자 취소하는 것을 테스트로 함)
![image](https://github.com/user-attachments/assets/72ef996f-4c88-443a-9963-67724b3887a0)



## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제