### PR TITLE
[FEAT] 채팅 기록 저장 및 채팅 로그 조회 및 참여 채팅방 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     // STOMP
     implementation 'org.webjars:stomp-websocket:2.3.4'
+
+    // mongoDB
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/barter/BarterApplication.java
+++ b/src/main/java/com/barter/BarterApplication.java
@@ -3,16 +3,17 @@ package com.barter;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
+@EnableMongoRepositories(basePackages = "com.barter.domain.chat.repository")
 public class BarterApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(BarterApplication.class, args);
 	}
-
 
 }

--- a/src/main/java/com/barter/BarterApplication.java
+++ b/src/main/java/com/barter/BarterApplication.java
@@ -9,6 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
+// 해당 경로의 repository 만 MongoDB 리포지토리로 인식 합니다. (안쓰면 INFO 로그에 엄청난 줄이 생깁니다.)
 @EnableMongoRepositories(basePackages = "com.barter.domain.chat.repository")
 public class BarterApplication {
 

--- a/src/main/java/com/barter/config/MongodbConfig.java
+++ b/src/main/java/com/barter/config/MongodbConfig.java
@@ -1,0 +1,26 @@
+package com.barter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.convert.DbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+@Configuration
+public class MongodbConfig {
+
+	// 해당 부분은 mongoDB 저장 시 _class 필드가 같이 저장되지 않도록 설정한 코드입니다.
+	@Bean
+	public MappingMongoConverter mappingMongoConverter(
+		MongoDatabaseFactory mongoDatabaseFactory,
+		MongoMappingContext mongoMappingContext
+	) {
+		DbRefResolver dbRefResolver = new DefaultDbRefResolver(mongoDatabaseFactory);
+		MappingMongoConverter converter = new MappingMongoConverter(dbRefResolver, mongoMappingContext);
+		converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+		return converter;
+	}
+}

--- a/src/main/java/com/barter/config/WebSocketConfig.java
+++ b/src/main/java/com/barter/config/WebSocketConfig.java
@@ -38,8 +38,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		// 웹소켓 (STOMP)  접속 주소 설정
 
 		registry.addEndpoint("/ws")
-			.setAllowedOrigins("*")
-			.withSockJS(); // js 로 테스트 시
+			.setAllowedOrigins("*");
+		//.withSockJS(); // js 로 테스트 시
 
 		registry.setErrorHandler(stompErrorHandler);
 

--- a/src/main/java/com/barter/domain/chat/collections/ChattingContent.java
+++ b/src/main/java/com/barter/domain/chat/collections/ChattingContent.java
@@ -1,5 +1,7 @@
 package com.barter.domain.chat.collections;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import jakarta.persistence.Id;
@@ -17,13 +19,15 @@ public class ChattingContent {
 	@Id
 	private String id;
 	private String roomId;
-	private String content;
+	private String message;
 	private Long userId;
+	private LocalDateTime chatTime;
 
 	@Builder
-	public ChattingContent(String roomId, String content, Long userId) {
+	public ChattingContent(String roomId, String message, Long userId) {
 		this.roomId = roomId;
-		this.content = content;
+		this.message = message;
 		this.userId = userId;
+		this.chatTime = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/barter/domain/chat/collections/ChattingContent.java
+++ b/src/main/java/com/barter/domain/chat/collections/ChattingContent.java
@@ -1,0 +1,29 @@
+package com.barter.domain.chat.collections;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "barter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChattingContent {
+	@Id
+	private String id;
+	private String roomId;
+	private String content;
+	private Long userId;
+
+	@Builder
+	public ChattingContent(String roomId, String content, Long userId) {
+		this.roomId = roomId;
+		this.content = content;
+		this.userId = userId;
+	}
+}

--- a/src/main/java/com/barter/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatController.java
@@ -6,7 +6,9 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.barter.domain.chat.collections.ChattingContent;
 import com.barter.domain.chat.dto.ChatMessageDto;
+import com.barter.domain.chat.repository.ChattingRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,17 +19,27 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatController {
 
 	private final SimpMessageSendingOperations template;
+	private final ChattingRepository chattingRepository;
 
 	@MessageMapping("/send-message")
 	public void sendMessage(@Payload ChatMessageDto chatMessageDto, StompHeaderAccessor headerAccessor) {
 
 		log.info("headerAccessor : {}", headerAccessor);
 		String userId = (String)headerAccessor.getSessionAttributes().get("userId");
+		String roomId = (String)headerAccessor.getSessionAttributes().get("roomId");
 		log.info("userId : {}", userId);
+
+		ChattingContent chattingContent = ChattingContent.builder()
+			.roomId(roomId)
+			.message(chatMessageDto.getMessage())
+			.userId(Long.valueOf(userId))
+			.build();
+
+		chattingRepository.save(chattingContent);
 
 		// 일단 이거는 한명이 나가도 유지되어야 함 (나중에 채팅 로그 저장하면 해당 로그를 보여줄 수 있음)
 		log.info("CHAT : {}", chatMessageDto.getMessage());
-		template.convertAndSend("/topic/chat/room/" + chatMessageDto.getRoomId(), chatMessageDto);
+		template.convertAndSend("/topic/chat/room/" + roomId, chatMessageDto);
 
 	}
 }

--- a/src/main/java/com/barter/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatController.java
@@ -3,7 +3,7 @@ package com.barter.domain.chat.controller;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.chat.dto.ChatMessageDto;
@@ -19,7 +19,11 @@ public class ChatController {
 	private final SimpMessageSendingOperations template;
 
 	@MessageMapping("/send-message")
-	public void sendMessage(@Payload ChatMessageDto chatMessageDto, MessageHeaderAccessor headerAccessor) {
+	public void sendMessage(@Payload ChatMessageDto chatMessageDto, StompHeaderAccessor headerAccessor) {
+
+		log.info("headerAccessor : {}", headerAccessor);
+		String userId = (String)headerAccessor.getSessionAttributes().get("userId");
+		log.info("userId : {}", userId);
 
 		// 일단 이거는 한명이 나가도 유지되어야 함 (나중에 채팅 로그 저장하면 해당 로그를 보여줄 수 있음)
 		log.info("CHAT : {}", chatMessageDto.getMessage());

--- a/src/main/java/com/barter/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatController.java
@@ -7,7 +7,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.chat.collections.ChattingContent;
-import com.barter.domain.chat.dto.ChatMessageDto;
+import com.barter.domain.chat.dto.request.ChatMessageReqDto;
 import com.barter.domain.chat.repository.ChattingRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ public class ChatController {
 	private final ChattingRepository chattingRepository;
 
 	@MessageMapping("/send-message")
-	public void sendMessage(@Payload ChatMessageDto chatMessageDto, StompHeaderAccessor headerAccessor) {
+	public void sendMessage(@Payload ChatMessageReqDto chatMessageReqDto, StompHeaderAccessor headerAccessor) {
 
 		log.info("headerAccessor : {}", headerAccessor);
 		String userId = (String)headerAccessor.getSessionAttributes().get("userId");
@@ -31,15 +31,15 @@ public class ChatController {
 
 		ChattingContent chattingContent = ChattingContent.builder()
 			.roomId(roomId)
-			.message(chatMessageDto.getMessage())
+			.message(chatMessageReqDto.getMessage())
 			.userId(Long.valueOf(userId))
 			.build();
 
 		chattingRepository.save(chattingContent);
 
 		// 일단 이거는 한명이 나가도 유지되어야 함 (나중에 채팅 로그 저장하면 해당 로그를 보여줄 수 있음)
-		log.info("CHAT : {}", chatMessageDto.getMessage());
-		template.convertAndSend("/topic/chat/room/" + roomId, chatMessageDto);
+		log.info("CHAT : {}", chatMessageReqDto.getMessage());
+		template.convertAndSend("/topic/chat/room/" + roomId, chatMessageReqDto);
 
 	}
 }

--- a/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
@@ -1,7 +1,11 @@
 package com.barter.domain.chat.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,7 +13,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.chat.dto.request.CreateChatRoomReqDto;
+import com.barter.domain.chat.dto.response.ChatMessageResDto;
 import com.barter.domain.chat.dto.response.CreateChatRoomResDto;
+import com.barter.domain.chat.service.ChatLogService;
 import com.barter.domain.chat.service.ChatRoomService;
 
 import lombok.RequiredArgsConstructor;
@@ -20,10 +26,16 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomController {
 
 	private final ChatRoomService chatRoomService;
+	private final ChatLogService chatLogService;
 
 	@PostMapping
 	public ResponseEntity<CreateChatRoomResDto> createChatRoom(VerifiedMember member,
 		@RequestBody CreateChatRoomReqDto reqDto) {
 		return ResponseEntity.status(HttpStatus.CREATED).body(chatRoomService.createChatRoom(member, reqDto));
+	}
+
+	@GetMapping("/{roomId}")
+	public ResponseEntity<List<ChatMessageResDto>> findChatsByRoom(@PathVariable String roomId) {
+		return ResponseEntity.status(HttpStatus.OK).body(chatLogService.findChatLogs(roomId));
 	}
 }

--- a/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
@@ -15,6 +15,7 @@ import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.chat.dto.request.CreateChatRoomReqDto;
 import com.barter.domain.chat.dto.response.ChatMessageResDto;
 import com.barter.domain.chat.dto.response.CreateChatRoomResDto;
+import com.barter.domain.chat.dto.response.FindChatRoomResDto;
 import com.barter.domain.chat.service.ChatLogService;
 import com.barter.domain.chat.service.ChatRoomService;
 
@@ -36,6 +37,11 @@ public class ChatRoomController {
 
 	@GetMapping("/{roomId}")
 	public ResponseEntity<List<ChatMessageResDto>> findChatsByRoom(@PathVariable String roomId) {
-		return ResponseEntity.status(HttpStatus.OK).body(chatLogService.findChatLogs(roomId));
+		return ResponseEntity.status(HttpStatus.OK).body(chatLogService.findChatsByRoom(roomId));
+	}
+
+	@GetMapping
+	public ResponseEntity<List<FindChatRoomResDto>> findRoomByMember(VerifiedMember member) {
+		return ResponseEntity.status(HttpStatus.OK).body(chatRoomService.findRoomByMember(member));
 	}
 }

--- a/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
@@ -1,7 +1,5 @@
 package com.barter.domain.chat.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
@@ -39,8 +37,9 @@ public class ChatRoomController {
 	}
 
 	@GetMapping("/{roomId}")
-	public ResponseEntity<List<ChatMessageResDto>> findChatsByRoom(@PathVariable String roomId) {
-		return ResponseEntity.status(HttpStatus.OK).body(chatLogService.findChatsByRoom(roomId));
+	public ResponseEntity<PagedModel<ChatMessageResDto>> findChatsByRoom(@PathVariable String roomId,
+		@PageableDefault Pageable pageable) {
+		return ResponseEntity.status(HttpStatus.OK).body(chatLogService.findChatsByRoom(roomId, pageable));
 	}
 
 	@GetMapping

--- a/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/barter/domain/chat/controller/ChatRoomController.java
@@ -2,6 +2,9 @@ package com.barter.domain.chat.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,7 +44,8 @@ public class ChatRoomController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<FindChatRoomResDto>> findRoomByMember(VerifiedMember member) {
-		return ResponseEntity.status(HttpStatus.OK).body(chatRoomService.findRoomByMember(member));
+	public ResponseEntity<PagedModel<FindChatRoomResDto>> findRoomsByMember(VerifiedMember member,
+		@PageableDefault Pageable pageable) {
+		return ResponseEntity.status(HttpStatus.OK).body(chatRoomService.findRoomsByMember(member, pageable));
 	}
 }

--- a/src/main/java/com/barter/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/ChatMessageDto.java
@@ -9,22 +9,15 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatMessageDto {
-	public enum MessageType {
-		TALK, LEAVE
-	}
 
-	private MessageType messageType;
 	private String roomId;
-	private String nickname;
 	private String message;
 	private String time;
 
 	@Builder
-	public ChatMessageDto(MessageType messageType, String roomId, String nickname,
+	public ChatMessageDto(String roomId, String nickname,
 		String message) {
-		this.messageType = messageType;
 		this.roomId = roomId;
-		this.nickname = nickname;
 		this.message = message;
 		this.time = LocalDateTime.now().toString();
 	}

--- a/src/main/java/com/barter/domain/chat/dto/request/ChatMessageReqDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/request/ChatMessageReqDto.java
@@ -1,24 +1,22 @@
-package com.barter.domain.chat.dto;
+package com.barter.domain.chat.dto.request;
 
 import java.time.LocalDateTime;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
-public class ChatMessageDto {
+public class ChatMessageReqDto {
 
 	private String roomId;
 	private String message;
 	private String time;
 
 	@Builder
-	public ChatMessageDto(String roomId, String nickname,
-		String message) {
+	public ChatMessageReqDto(String roomId, String message) {
 		this.roomId = roomId;
 		this.message = message;
 		this.time = LocalDateTime.now().toString();
 	}
+
 }

--- a/src/main/java/com/barter/domain/chat/dto/response/ChatMessageResDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/response/ChatMessageResDto.java
@@ -1,0 +1,40 @@
+package com.barter.domain.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.barter.domain.chat.collections.ChattingContent;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ChatMessageResDto {
+
+	private String roomId;
+	private String message;
+	private LocalDateTime chatTime;
+
+	@Builder
+	public ChatMessageResDto(String roomId, String message, LocalDateTime time) {
+		this.roomId = roomId;
+		this.message = message;
+		this.chatTime = time;
+	}
+
+	@Override
+	public String toString() {
+		return "ChatMessageDto [roomId=" + roomId + ", message=" + message + ", chatTime=" + chatTime + "]";
+	}
+
+	public static List<ChatMessageResDto> from(List<ChattingContent> chats) {
+
+		return chats.stream()
+			.map(chat -> ChatMessageResDto.builder()
+				.roomId(chat.getRoomId())
+				.message(chat.getMessage())
+				.time(chat.getChatTime())
+				.build())
+			.toList();
+	}
+}

--- a/src/main/java/com/barter/domain/chat/dto/response/ChatMessageResDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/response/ChatMessageResDto.java
@@ -1,7 +1,6 @@
 package com.barter.domain.chat.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.barter.domain.chat.collections.ChattingContent;
 
@@ -16,10 +15,10 @@ public class ChatMessageResDto {
 	private LocalDateTime chatTime;
 
 	@Builder
-	public ChatMessageResDto(String roomId, String message, LocalDateTime time) {
+	public ChatMessageResDto(String roomId, String message, LocalDateTime chatTime) {
 		this.roomId = roomId;
 		this.message = message;
-		this.chatTime = time;
+		this.chatTime = chatTime;
 	}
 
 	@Override
@@ -27,14 +26,12 @@ public class ChatMessageResDto {
 		return "ChatMessageDto [roomId=" + roomId + ", message=" + message + ", chatTime=" + chatTime + "]";
 	}
 
-	public static List<ChatMessageResDto> from(List<ChattingContent> chats) {
+	public static ChatMessageResDto from(ChattingContent chattingContent) {
 
-		return chats.stream()
-			.map(chat -> ChatMessageResDto.builder()
-				.roomId(chat.getRoomId())
-				.message(chat.getMessage())
-				.time(chat.getChatTime())
-				.build())
-			.toList();
+		return ChatMessageResDto.builder()
+			.roomId(chattingContent.getRoomId())
+			.message(chattingContent.getMessage())
+			.chatTime(chattingContent.getChatTime())
+			.build();
 	}
 }

--- a/src/main/java/com/barter/domain/chat/dto/response/FindChatRoomResDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/response/FindChatRoomResDto.java
@@ -1,0 +1,34 @@
+package com.barter.domain.chat.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.barter.domain.chat.entity.ChatRoomMember;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FindChatRoomResDto {
+	private String roomId;
+	private LocalDateTime createdAt;
+
+	@Builder
+	public FindChatRoomResDto(String roomId, LocalDateTime createdAt) {
+		this.roomId = roomId;
+		this.createdAt = createdAt;
+	}
+
+	public static List<FindChatRoomResDto> from(List<ChatRoomMember> chatRoomMembers) {
+
+		return chatRoomMembers.stream()
+			.map(chatRoomMember ->
+				FindChatRoomResDto.builder()
+					.roomId(chatRoomMember.getChatRoom().getId())
+					.createdAt(chatRoomMember.getChatRoom().getCreatedAt())
+					.build()
+			).toList();
+
+	}
+
+}

--- a/src/main/java/com/barter/domain/chat/dto/response/FindChatRoomResDto.java
+++ b/src/main/java/com/barter/domain/chat/dto/response/FindChatRoomResDto.java
@@ -1,7 +1,6 @@
 package com.barter.domain.chat.dto.response;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.barter.domain.chat.entity.ChatRoomMember;
 
@@ -19,15 +18,12 @@ public class FindChatRoomResDto {
 		this.createdAt = createdAt;
 	}
 
-	public static List<FindChatRoomResDto> from(List<ChatRoomMember> chatRoomMembers) {
+	public static FindChatRoomResDto from(ChatRoomMember chatRoomMember) {
 
-		return chatRoomMembers.stream()
-			.map(chatRoomMember ->
-				FindChatRoomResDto.builder()
-					.roomId(chatRoomMember.getChatRoom().getId())
-					.createdAt(chatRoomMember.getChatRoom().getCreatedAt())
-					.build()
-			).toList();
+		return FindChatRoomResDto.builder()
+			.roomId(chatRoomMember.getChatRoom().getId())
+			.createdAt(chatRoomMember.getMember().getCreatedAt())
+			.build();
 
 	}
 

--- a/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
@@ -1,9 +1,14 @@
 package com.barter.domain.chat.event;
 
+import java.util.List;
+
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import com.barter.domain.chat.dto.response.ChatMessageResDto;
 import com.barter.domain.chat.enums.JoinStatus;
+import com.barter.domain.chat.service.ChatLogService;
 import com.barter.domain.chat.service.ChatRoomService;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatRoomEventListener {
 
 	private final ChatRoomService chatRoomService;
+	private final ChatLogService chatLogService;
+	private final SimpMessagingTemplate simpMessagingTemplate;
 
 	@EventListener
 	public void handleUserSubscribedEvent(MemberSubscribedEvent event) {
@@ -23,6 +30,13 @@ public class ChatRoomEventListener {
 		try {
 			chatRoomService.changeRoomStatus(event.getRoomId());
 			chatRoomService.updateMemberJoinStatus(event.getRoomId(), event.getMemberId(), JoinStatus.IN_ROOM);
+
+			List<ChatMessageResDto> chatLogs = chatLogService.findChatLogs(event.getRoomId());
+			log.info("chatLogs: {}", chatLogs);
+			simpMessagingTemplate.convertAndSendToUser(String.valueOf(event.getMemberId()),
+				"/topic/chat/room/" + event.getRoomId(),
+				chatLogs);
+			// TODO :  해당 유저가 반복적으로 방을 나갔다 들어오는 경우에 대한 성능 개선 필요 (ex : cache)
 
 			log.info("멤버 채팅방 구독 성공 : {} 유저가 {} 방에 구독 중", event.getMemberId(), event.getRoomId());
 

--- a/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
+++ b/src/main/java/com/barter/domain/chat/event/ChatRoomEventListener.java
@@ -1,14 +1,9 @@
 package com.barter.domain.chat.event;
 
-import java.util.List;
-
 import org.springframework.context.event.EventListener;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
-import com.barter.domain.chat.dto.response.ChatMessageResDto;
 import com.barter.domain.chat.enums.JoinStatus;
-import com.barter.domain.chat.service.ChatLogService;
 import com.barter.domain.chat.service.ChatRoomService;
 
 import lombok.RequiredArgsConstructor;
@@ -20,8 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatRoomEventListener {
 
 	private final ChatRoomService chatRoomService;
-	private final ChatLogService chatLogService;
-	private final SimpMessagingTemplate simpMessagingTemplate;
 
 	@EventListener
 	public void handleUserSubscribedEvent(MemberSubscribedEvent event) {
@@ -30,13 +23,6 @@ public class ChatRoomEventListener {
 		try {
 			chatRoomService.changeRoomStatus(event.getRoomId());
 			chatRoomService.updateMemberJoinStatus(event.getRoomId(), event.getMemberId(), JoinStatus.IN_ROOM);
-
-			List<ChatMessageResDto> chatLogs = chatLogService.findChatLogs(event.getRoomId());
-			log.info("chatLogs: {}", chatLogs);
-			simpMessagingTemplate.convertAndSendToUser(String.valueOf(event.getMemberId()),
-				"/topic/chat/room/" + event.getRoomId(),
-				chatLogs);
-			// TODO :  해당 유저가 반복적으로 방을 나갔다 들어오는 경우에 대한 성능 개선 필요 (ex : cache)
 
 			log.info("멤버 채팅방 구독 성공 : {} 유저가 {} 방에 구독 중", event.getMemberId(), event.getRoomId());
 

--- a/src/main/java/com/barter/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/barter/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,8 +1,9 @@
 package com.barter.domain.chat.repository;
 
-import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.barter.domain.chat.entity.ChatRoomMember;
@@ -13,5 +14,5 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
 	Optional<ChatRoomMember> findByChatRoomIdAndMemberId(String roomId, Long memberId);
 
-	List<ChatRoomMember> findAllByMemberId(Long id);
+	Page<ChatRoomMember> findAllByMemberId(Long id, Pageable pageable);
 }

--- a/src/main/java/com/barter/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/barter/domain/chat/repository/ChatRoomMemberRepository.java
@@ -1,5 +1,6 @@
 package com.barter.domain.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 	long countByChatRoomIdAndJoinStatus(String roomId, JoinStatus joinStatus);
 
 	Optional<ChatRoomMember> findByChatRoomIdAndMemberId(String roomId, Long memberId);
+
+	List<ChatRoomMember> findAllByMemberId(Long id);
 }

--- a/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
+++ b/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
@@ -1,11 +1,11 @@
 package com.barter.domain.chat.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.barter.domain.chat.collections.ChattingContent;
 
 public interface ChattingRepository extends MongoRepository<ChattingContent, String> {
-	List<ChattingContent> findByRoomIdOrderByChatTimeDesc(String roomId);
+	Page<ChattingContent> findByRoomIdOrderByChatTimeDesc(String roomId, Pageable pageable);
 }

--- a/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
+++ b/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import com.barter.domain.chat.collections.ChattingContent;
 
 public interface ChattingRepository extends MongoRepository<ChattingContent, String> {
-	List<ChattingContent> findByRoomId(String roomId);
+	List<ChattingContent> findByRoomIdOrderByChatTimeDesc(String roomId);
 }

--- a/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
+++ b/src/main/java/com/barter/domain/chat/repository/ChattingRepository.java
@@ -1,0 +1,11 @@
+package com.barter.domain.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.barter.domain.chat.collections.ChattingContent;
+
+public interface ChattingRepository extends MongoRepository<ChattingContent, String> {
+	List<ChattingContent> findByRoomId(String roomId);
+}

--- a/src/main/java/com/barter/domain/chat/service/ChatLogService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatLogService.java
@@ -1,0 +1,24 @@
+package com.barter.domain.chat.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.barter.domain.chat.dto.response.ChatMessageResDto;
+import com.barter.domain.chat.repository.ChattingRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatLogService {
+
+	private final ChattingRepository chattingRepository;
+
+	public List<ChatMessageResDto> findChatLogs(String roomId) {
+
+		return ChatMessageResDto.from(chattingRepository.findByRoomIdOrderByChatTimeDesc(roomId));
+		// TODO : 추후 개수 제한이나 Page 객체로 묶을 생각입니다.
+	}
+
+}

--- a/src/main/java/com/barter/domain/chat/service/ChatLogService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatLogService.java
@@ -15,10 +15,10 @@ public class ChatLogService {
 
 	private final ChattingRepository chattingRepository;
 
-	public List<ChatMessageResDto> findChatLogs(String roomId) {
+	public List<ChatMessageResDto> findChatsByRoom(String roomId) {
 
 		return ChatMessageResDto.from(chattingRepository.findByRoomIdOrderByChatTimeDesc(roomId));
-		// TODO : 추후 개수 제한이나 Page 객체로 묶을 생각입니다.
+
 	}
 
 }

--- a/src/main/java/com/barter/domain/chat/service/ChatLogService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatLogService.java
@@ -1,7 +1,8 @@
 package com.barter.domain.chat.service;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 
 import com.barter.domain.chat.dto.response.ChatMessageResDto;
@@ -15,9 +16,11 @@ public class ChatLogService {
 
 	private final ChattingRepository chattingRepository;
 
-	public List<ChatMessageResDto> findChatsByRoom(String roomId) {
+	public PagedModel<ChatMessageResDto> findChatsByRoom(String roomId, Pageable pageable) {
 
-		return ChatMessageResDto.from(chattingRepository.findByRoomIdOrderByChatTimeDesc(roomId));
+		Page<ChatMessageResDto> chatMessageResDtos = chattingRepository.findByRoomIdOrderByChatTimeDesc(roomId,
+			pageable).map(ChatMessageResDto::from);
+		return new PagedModel<>(chatMessageResDtos);
 
 	}
 

--- a/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
@@ -1,7 +1,8 @@
 package com.barter.domain.chat.service;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -105,10 +106,11 @@ public class ChatRoomService {
 	}
 
 	@Transactional
-	public List<FindChatRoomResDto> findRoomByMember(VerifiedMember member) {
+	public PagedModel<FindChatRoomResDto> findRoomsByMember(VerifiedMember member, Pageable pageable) {
 
-		List<ChatRoomMember> chatRoomMembers = chatRoomMemberRepository.findAllByMemberId(member.getId());
+		Page<FindChatRoomResDto> chatRoomMembers = chatRoomMemberRepository.findAllByMemberId(member.getId(), pageable)
+			.map(FindChatRoomResDto::from);
+		return new PagedModel<>(chatRoomMembers);
 
-		return FindChatRoomResDto.from(chatRoomMembers);
 	}
 }

--- a/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
@@ -70,7 +70,7 @@ public class ChatRoomService {
 
 		long userCount = chatRoomMemberRepository.countByChatRoomIdAndJoinStatus(roomId, JoinStatus.IN_ROOM);
 
-		if (userCount == 2) {
+		if (userCount == 1) { // (이전 값 : 2), 1명이 들어가고 또 한명이 들어감과 동시에 IN_PROGRESS 가 되어야 하는데, 2 라면, 3명을 기대하는 꼴이 된다.
 			chatRoom.updateStatus(RoomStatus.IN_PROGRESS);
 		}
 

--- a/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/barter/domain/chat/service/ChatRoomService.java
@@ -1,12 +1,14 @@
 package com.barter.domain.chat.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.chat.dto.request.CreateChatRoomReqDto;
 import com.barter.domain.chat.dto.response.CreateChatRoomResDto;
+import com.barter.domain.chat.dto.response.FindChatRoomResDto;
 import com.barter.domain.chat.entity.ChatRoom;
 import com.barter.domain.chat.entity.ChatRoomMember;
 import com.barter.domain.chat.enums.JoinStatus;
@@ -28,7 +30,6 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 	private final MemberRepository memberRepository;
 	private final RegisteredProductRepository registeredProductRepository;
-	private final TransactionTemplate transactionTemplate;
 
 	@Transactional
 	public CreateChatRoomResDto createChatRoom(VerifiedMember member, CreateChatRoomReqDto reqDto) {
@@ -101,5 +102,13 @@ public class ChatRoomService {
 			chatRoom.updateStatus(RoomStatus.CLOSED); // 한 명이라도 나가면 CLOSED
 		}
 		chatRoomMember.changeJoinStatus(joinStatus);
+	}
+
+	@Transactional
+	public List<FindChatRoomResDto> findRoomByMember(VerifiedMember member) {
+
+		List<ChatRoomMember> chatRoomMembers = chatRoomMemberRepository.findAllByMemberId(member.getId());
+
+		return FindChatRoomResDto.from(chatRoomMembers);
 	}
 }


### PR DESCRIPTION
## 개요

- [x] 채팅 메시지를 send 함과 동시에 연결된 nosql 에 채팅 기록이 저장됨
- [x] 해당 채팅방의 채팅 로글를 조회 할 수 있음
- [x] 자신이 참여중인 채팅방의 리스트를 조회할 수 있음
- [x] nosql 저장 시 `_class` 는 저장되지 않도록 함 (저장 정보) - 아래 이미지 참고하면 좋을 것 같아요 (MongodbConfig 참고)


 Resolves: #258 

* _class 유무 비교

![image](https://github.com/user-attachments/assets/d0b159c5-75c8-4118-b277-854bc3304a7c)



* 채팅 저장 예시
![image](https://github.com/user-attachments/assets/5eda0b28-267e-46f7-91b0-4b3591bb72d3)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제