### PR TITLE
[FEAT] 사용 가능한 물품(등록, 제안) 다건 조회 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
@@ -27,7 +27,7 @@ import com.barter.domain.product.dto.request.SwitchRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
-import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.dto.response.SwitchRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
@@ -116,7 +116,7 @@ public class RegisteredProductController {
 
 	@GetMapping("/available")
 	@ResponseStatus(HttpStatus.OK)
-	public List<FindAvailableRegisteredProductsResDto> findAvailableRegisteredProducts(VerifiedMember verifiedMember) {
+	public List<FindAvailableRegisteredProductResDto> findAvailableRegisteredProducts(VerifiedMember verifiedMember) {
 		return registeredProductService.findAvailableRegisteredProducts(verifiedMember.getId());
 	}
 }

--- a/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/RegisteredProductController.java
@@ -27,10 +27,11 @@ import com.barter.domain.product.dto.request.SwitchRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
+import com.barter.domain.product.dto.response.SwitchRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductStatusResDto;
-import com.barter.domain.product.dto.response.SwitchRegisteredProductResDto;
 import com.barter.domain.product.service.ProductSwitchService;
 import com.barter.domain.product.service.RegisteredProductService;
 
@@ -111,5 +112,11 @@ public class RegisteredProductController {
 		return productSwitchService.createRegisteredProductFromSuggestedProduct(
 			request.getSuggestedProductId(), verifiedMember.getId()
 		);
+	}
+
+	@GetMapping("/available")
+	@ResponseStatus(HttpStatus.OK)
+	public List<FindAvailableRegisteredProductsResDto> findAvailableRegisteredProducts(VerifiedMember verifiedMember) {
+		return registeredProductService.findAvailableRegisteredProducts(verifiedMember.getId());
 	}
 }

--- a/src/main/java/com/barter/domain/product/controller/SuggestedProductController.java
+++ b/src/main/java/com/barter/domain/product/controller/SuggestedProductController.java
@@ -27,10 +27,11 @@ import com.barter.domain.product.dto.request.SwitchSuggestedProductReqDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateSuggestedProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableSuggestedProductResDto;
 import com.barter.domain.product.dto.response.FindSuggestedProductResDto;
+import com.barter.domain.product.dto.response.SwitchSuggestedProductResDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductStatusResDto;
-import com.barter.domain.product.dto.response.SwitchSuggestedProductResDto;
 import com.barter.domain.product.service.ProductSwitchService;
 import com.barter.domain.product.service.SuggestedProductService;
 
@@ -111,5 +112,11 @@ public class SuggestedProductController {
 		return productSwitchService.createSuggestedProductFromRegisteredProduct(
 			request.getRegisteredProductId(), verifiedMember.getId()
 		);
+	}
+
+	@GetMapping("/available")
+	@ResponseStatus(HttpStatus.OK)
+	public List<FindAvailableSuggestedProductResDto> findAvailableSuggestedProducts(VerifiedMember verifiedMember) {
+		return suggestedProductService.findAvailableSuggestedProducts(verifiedMember.getId());
 	}
 }

--- a/src/main/java/com/barter/domain/product/dto/response/FindAvailableRegisteredProductResDto.java
+++ b/src/main/java/com/barter/domain/product/dto/response/FindAvailableRegisteredProductResDto.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class FindAvailableRegisteredProductsResDto {
+public class FindAvailableRegisteredProductResDto {
 
 	private Long id;
 	private String name;
 
-	public static FindAvailableRegisteredProductsResDto from(RegisteredProduct registeredProduct) {
-		return FindAvailableRegisteredProductsResDto.builder()
+	public static FindAvailableRegisteredProductResDto from(RegisteredProduct registeredProduct) {
+		return FindAvailableRegisteredProductResDto.builder()
 			.id(registeredProduct.getId())
 			.name(registeredProduct.getName())
 			.build();

--- a/src/main/java/com/barter/domain/product/dto/response/FindAvailableRegisteredProductsResDto.java
+++ b/src/main/java/com/barter/domain/product/dto/response/FindAvailableRegisteredProductsResDto.java
@@ -1,0 +1,21 @@
+package com.barter.domain.product.dto.response;
+
+import com.barter.domain.product.entity.RegisteredProduct;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindAvailableRegisteredProductsResDto {
+
+	private Long id;
+	private String name;
+
+	public static FindAvailableRegisteredProductsResDto from(RegisteredProduct registeredProduct) {
+		return FindAvailableRegisteredProductsResDto.builder()
+			.id(registeredProduct.getId())
+			.name(registeredProduct.getName())
+			.build();
+	}
+}

--- a/src/main/java/com/barter/domain/product/dto/response/FindAvailableSuggestedProductResDto.java
+++ b/src/main/java/com/barter/domain/product/dto/response/FindAvailableSuggestedProductResDto.java
@@ -1,0 +1,21 @@
+package com.barter.domain.product.dto.response;
+
+import com.barter.domain.product.entity.SuggestedProduct;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindAvailableSuggestedProductResDto {
+
+	private Long id;
+	private String name;
+
+	public static FindAvailableSuggestedProductResDto from(SuggestedProduct suggestedProduct) {
+		return FindAvailableSuggestedProductResDto.builder()
+			.id(suggestedProduct.getId())
+			.name(suggestedProduct.getName())
+			.build();
+	}
+}

--- a/src/main/java/com/barter/domain/product/repository/RegisteredProductRepository.java
+++ b/src/main/java/com/barter/domain/product/repository/RegisteredProductRepository.java
@@ -1,5 +1,7 @@
 package com.barter.domain.product.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +14,7 @@ public interface RegisteredProductRepository extends JpaRepository<RegisteredPro
 
 	@Query(value = "SELECT rp FROM RegisteredProduct AS rp WHERE rp.member.id = :memberId")
 	Page<RegisteredProduct> findAllByMemberId(Pageable pageable, @Param("memberId") Long memberId);
+
+	@Query(value = "SELECT rp FROM RegisteredProduct AS rp WHERE rp.member.id = :memberId AND rp.status = 'PENDING'")
+	List<RegisteredProduct> findAllAvailableRegisteredProduct(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/barter/domain/product/repository/SuggestedProductRepository.java
+++ b/src/main/java/com/barter/domain/product/repository/SuggestedProductRepository.java
@@ -1,5 +1,7 @@
 package com.barter.domain.product.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +14,7 @@ public interface SuggestedProductRepository extends JpaRepository<SuggestedProdu
 
 	@Query(value = "SELECT sp FROM SuggestedProduct AS sp WHERE sp.member.id = :memberId")
 	Page<SuggestedProduct> findAllByMemberId(Pageable pageable, @Param("memberId") Long memberId);
+
+	@Query(value = "SELECT sp FROM SuggestedProduct AS sp WHERE sp.member.id = :memberId AND sp.status = 'PENDING'")
+	List<SuggestedProduct> findAllAvailableSuggestedProduct(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
+++ b/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
@@ -15,7 +15,7 @@ import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
-import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductStatusResDto;
@@ -118,10 +118,10 @@ public class RegisteredProductService {
 		registeredProductRepository.delete(foundProduct);
 	}
 
-	public List<FindAvailableRegisteredProductsResDto> findAvailableRegisteredProducts(Long verifiedMemberId) {
+	public List<FindAvailableRegisteredProductResDto> findAvailableRegisteredProducts(Long verifiedMemberId) {
 		List<RegisteredProduct> foundProducts = registeredProductRepository.findAllAvailableRegisteredProduct(
 			verifiedMemberId);
 
-		return foundProducts.stream().map(FindAvailableRegisteredProductsResDto::from).toList();
+		return foundProducts.stream().map(FindAvailableRegisteredProductResDto::from).toList();
 	}
 }

--- a/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
+++ b/src/main/java/com/barter/domain/product/service/RegisteredProductService.java
@@ -15,6 +15,7 @@ import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductStatusResDto;
@@ -117,4 +118,10 @@ public class RegisteredProductService {
 		registeredProductRepository.delete(foundProduct);
 	}
 
+	public List<FindAvailableRegisteredProductsResDto> findAvailableRegisteredProducts(Long verifiedMemberId) {
+		List<RegisteredProduct> foundProducts = registeredProductRepository.findAllAvailableRegisteredProduct(
+			verifiedMemberId);
+
+		return foundProducts.stream().map(FindAvailableRegisteredProductsResDto::from).toList();
+	}
 }

--- a/src/main/java/com/barter/domain/product/service/SuggestedProductService.java
+++ b/src/main/java/com/barter/domain/product/service/SuggestedProductService.java
@@ -15,6 +15,7 @@ import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateSuggestedProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableSuggestedProductResDto;
 import com.barter.domain.product.dto.response.FindSuggestedProductResDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductStatusResDto;
@@ -113,5 +114,12 @@ public class SuggestedProductService {
 			foundProduct.getImages().forEach(s3Service::deleteFile);
 		}
 		suggestedProductRepository.delete(foundProduct);
+	}
+
+	public List<FindAvailableSuggestedProductResDto> findAvailableSuggestedProducts(Long verifiedMemberId) {
+		List<SuggestedProduct> foundProducts = suggestedProductRepository.findAllAvailableSuggestedProduct(
+			verifiedMemberId);
+
+		return foundProducts.stream().map(FindAvailableSuggestedProductResDto::from).toList();
 	}
 }

--- a/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
+++ b/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
@@ -31,6 +31,7 @@ import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductStatusResDto;
@@ -591,4 +592,55 @@ public class RegisteredProductServiceTest {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("PENDING 상태인 경우에만 등록 물품을 삭제할 수 있습니다.");
 	}
+
+	@Test
+	@DisplayName("사용 가능한 등록 물품 다건 조회 - 성공 테스트")
+	void findAvailableRegisteredProductsTest_Success() {
+		//given
+		Long verifiedMemberId = 1L;
+
+		RegisteredProduct product1 = RegisteredProduct.builder()
+			.id(1L)
+			.name("test product1")
+			.description("test product1 description")
+			.images(List.of("test product1 image1", "test product1 image2"))
+			.status(RegisteredStatus.PENDING)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		RegisteredProduct product2 = RegisteredProduct.builder()
+			.id(2L)
+			.name("test product2")
+			.description("test product2 description")
+			.images(List.of("test product2 image1", "test product2 image2"))
+			.status(RegisteredStatus.PENDING)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		RegisteredProduct product3 = RegisteredProduct.builder()
+			.id(3L)
+			.name("test product3")
+			.description("test product3 description")
+			.images(List.of("test product3 image1", "test product3 image2"))
+			.status(RegisteredStatus.REGISTERING)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		when(registeredProductRepository.findAllAvailableRegisteredProduct(verifiedMemberId)).thenReturn(
+			List.of(product1, product2)
+		);
+
+		//when
+		List<FindAvailableRegisteredProductsResDto> response = registeredProductService.findAvailableRegisteredProducts(
+			verifiedMemberId);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response).hasSize(2);
+		assertThat(response.get(0).getId()).isEqualTo(1L);
+		assertThat(response.get(0).getName()).isEqualTo("test product1");
+		assertThat(response.get(1).getId()).isEqualTo(2L);
+		assertThat(response.get(1).getName()).isEqualTo("test product2");
+	}
+
 }

--- a/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
+++ b/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
@@ -31,7 +31,7 @@ import com.barter.domain.product.dto.request.CreateRegisteredProductReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductInfoReqDto;
 import com.barter.domain.product.dto.request.UpdateRegisteredProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateRegisteredProductResDto;
-import com.barter.domain.product.dto.response.FindAvailableRegisteredProductsResDto;
+import com.barter.domain.product.dto.response.FindAvailableRegisteredProductResDto;
 import com.barter.domain.product.dto.response.FindRegisteredProductResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateRegisteredProductStatusResDto;
@@ -631,7 +631,7 @@ public class RegisteredProductServiceTest {
 		);
 
 		//when
-		List<FindAvailableRegisteredProductsResDto> response = registeredProductService.findAvailableRegisteredProducts(
+		List<FindAvailableRegisteredProductResDto> response = registeredProductService.findAvailableRegisteredProducts(
 			verifiedMemberId);
 
 		//then

--- a/src/test/java/com/barter/domain/product/SuggestedProductServiceTest.java
+++ b/src/test/java/com/barter/domain/product/SuggestedProductServiceTest.java
@@ -7,8 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,23 +16,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.barter.common.s3.S3Service;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
-import com.barter.domain.product.dto.response.CreateSuggestedProductResDto;
-import com.barter.domain.product.dto.response.FindSuggestedProductResDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductInfoReqDto;
-import com.barter.domain.product.dto.response.UpdateSuggestedProductInfoResDto;
 import com.barter.domain.product.dto.request.UpdateSuggestedProductStatusReqDto;
+import com.barter.domain.product.dto.response.CreateSuggestedProductResDto;
+import com.barter.domain.product.dto.response.FindAvailableSuggestedProductResDto;
+import com.barter.domain.product.dto.response.FindSuggestedProductResDto;
+import com.barter.domain.product.dto.response.UpdateSuggestedProductInfoResDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductStatusResDto;
 import com.barter.domain.product.entity.SuggestedProduct;
 import com.barter.domain.product.enums.SuggestedStatus;
@@ -592,5 +593,55 @@ public class SuggestedProductServiceTest {
 			suggestedProductService.deleteSuggestedProduct(suggestedProductId, verifiedMemberId))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("PENDING 상태인 경우에만 제안 물품을 삭제할 수 있습니다.");
+	}
+
+	@Test
+	@DisplayName("사용 가능한 제안 물품 다건 조회 - 성공 테스트")
+	void findAvailableSuggestedProductsTest_Success() {
+		//given
+		Long verifiedMemberId = 1L;
+
+		SuggestedProduct product1 = SuggestedProduct.builder()
+			.id(1L)
+			.name("test product1")
+			.description("product1 description")
+			.images(List.of("product1 image1", "product1 image2"))
+			.status(SuggestedStatus.PENDING)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		SuggestedProduct product2 = SuggestedProduct.builder()
+			.id(2L)
+			.name("test product2")
+			.description("product2 description")
+			.images(List.of("product2 image1"))
+			.status(SuggestedStatus.PENDING)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		SuggestedProduct product3 = SuggestedProduct.builder()
+			.id(3L)
+			.name("test product3")
+			.description("product3 description")
+			.images(List.of("product3 image1", "product3 image2", "product3 image3"))
+			.status(SuggestedStatus.ACCEPTED)
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+
+		when(suggestedProductRepository.findAllAvailableSuggestedProduct(verifiedMemberId)).thenReturn(
+			List.of(product1, product2)
+		);
+
+		//when
+		List<FindAvailableSuggestedProductResDto> response = suggestedProductService.findAvailableSuggestedProducts(
+			verifiedMemberId);
+
+		//then
+		assertThat(response).isNotNull();
+		assertThat(response).hasSize(2);
+		assertThat(response.get(0).getId()).isEqualTo(1L);
+		assertThat(response.get(0).getName()).isEqualTo("test product1");
+		assertThat(response.get(1).getId()).isEqualTo(2L);
+		assertThat(response.get(1).getName()).isEqualTo("test product2");
 	}
 }


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
아래와 같은 이유로 신규 기능을 추가했습니다!
1. `교환 생성` 페이지에서 회원의 사용 가능한 `등록 물품 목록` 정보가 필요
2. `제안 신청` 페이지에서 회원의 사용 가능한 `제안 물품 목록` 정보가 필요

등록 물품과 제안 물품 각각 해당 기능을 구현하였습니다. 자세한 내용은 아래의 이슈를 통해 정확하게 확인 가능합니다.
- 기능 구현과 동시에 테스트 코드 또한 작성하였습니다.

Resolves: #267 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제