### PR TITLE
[FEAT] Custom Exception 구현

### DIFF
--- a/src/main/java/com/barter/domain/auth/exception/AccountLockedException.java
+++ b/src/main/java/com/barter/domain/auth/exception/AccountLockedException.java
@@ -1,4 +1,0 @@
-package com.barter.domain.auth.exception;
-
-public class AccountLockedException {
-}

--- a/src/main/java/com/barter/domain/auth/exception/DuplicateEmailException.java
+++ b/src/main/java/com/barter/domain/auth/exception/DuplicateEmailException.java
@@ -1,7 +1,0 @@
-package com.barter.domain.auth.exception;
-
-public class DuplicateEmailException extends RuntimeException {
-    public DuplicateEmailException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/barter/domain/auth/exception/InvalidCredentialsException.java
+++ b/src/main/java/com/barter/domain/auth/exception/InvalidCredentialsException.java
@@ -1,7 +1,0 @@
-package com.barter.domain.auth.exception;
-
-public class InvalidCredentialsException extends RuntimeException {
-    public InvalidCredentialsException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/barter/domain/auth/service/AuthService.java
+++ b/src/main/java/com/barter/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.barter.domain.auth.service;
 
+import static com.barter.exception.enums.ExceptionCode.*;
+
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -8,13 +10,13 @@ import org.springframework.util.StringUtils;
 import com.barter.domain.auth.dto.SignInReqDto;
 import com.barter.domain.auth.dto.SignInResDto;
 import com.barter.domain.auth.dto.SignUpReqDto;
-import com.barter.domain.auth.exception.DuplicateEmailException;
-import com.barter.domain.auth.exception.InvalidCredentialsException;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.member.repository.MemberRepository;
 import com.barter.domain.oauth.dto.LoginOAuthMemberDto;
 import com.barter.domain.oauth.dto.LoginOAuthMemberResDto;
 import com.barter.domain.oauth.enums.OAuthProvider;
+import com.barter.exception.customexceptions.AuthException;
+import com.barter.exception.customexceptions.MemberException;
 import com.barter.security.JwtUtil;
 import com.barter.security.PasswordEncoder;
 
@@ -34,7 +36,7 @@ public class AuthService {
 
 		// 이메일 중복 검증
 		if (memberRepository.existsByEmail(req.getEmail())) {
-			throw new DuplicateEmailException("중복된 이메일입니다.");
+			throw new AuthException(DUPLICATE_EMAIL);
 		}
 
 		// 비밀번호 암호화 후 저장
@@ -65,36 +67,36 @@ public class AuthService {
 
 	public SignInResDto signIn(SignInReqDto req) {
 		Member member = memberRepository.findByEmail(req.getEmail())
-				.orElseThrow(() -> new InvalidCredentialsException("존재하지 않는 사용자입니다."));
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 		if (!passwordEncoder.matches(req.getPassword(), member.getPassword())) {
-			throw new InvalidCredentialsException("비밀번호가 일치하지 않습니다.");
+			throw new AuthException(INVALID_PASSWORD);
 		}
 		String token = jwtUtil.createToken(member.getId(), member.getEmail());
 		return SignInResDto.builder()
-				.accessToken(token)
-				.build();
+			.accessToken(token)
+			.build();
 	}
 
 	public void signupWithOAuth(OAuthProvider provider, LoginOAuthMemberDto memberInfo) {
 		UUID uuid = UUID.randomUUID();
 		Member socialMember = Member.builder()
-				.provider(provider)
-				.providerId(memberInfo.getId())
-				.email(memberInfo.getEmail())
-				.password(passwordEncoder.encode(uuid.toString()))
-				.nickname(memberInfo.getNickname())
-				.build();
+			.provider(provider)
+			.providerId(memberInfo.getId())
+			.email(memberInfo.getEmail())
+			.password(passwordEncoder.encode(uuid.toString()))
+			.nickname(memberInfo.getNickname())
+			.build();
 		memberRepository.save(socialMember);
 	}
 
 	public LoginOAuthMemberResDto signinWithOAuth(OAuthProvider provider, LoginOAuthMemberDto memberInfo) {
 		return memberRepository.findByProviderAndProviderId(provider, memberInfo.getId())
-				.map(member -> {
-					String accessToken = jwtUtil.createToken(member.getId(), member.getEmail());
-					return LoginOAuthMemberResDto.builder()
-							.accessToken(accessToken)
-							.build();
-				})
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버입니다."));
+			.map(member -> {
+				String accessToken = jwtUtil.createToken(member.getId(), member.getEmail());
+				return LoginOAuthMemberResDto.builder()
+					.accessToken(accessToken)
+					.build();
+			})
+			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 	}
 }

--- a/src/main/java/com/barter/exception/ExpectedException.java
+++ b/src/main/java/com/barter/exception/ExpectedException.java
@@ -1,0 +1,25 @@
+package com.barter.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.barter.exception.enums.ExceptionCode;
+
+import lombok.Getter;
+
+@Getter
+public class ExpectedException extends RuntimeException {
+
+	private final ExceptionCode exceptionCode;
+
+	public ExpectedException(ExceptionCode exceptionCode) {
+		this.exceptionCode = exceptionCode;
+	}
+
+	public String getExceptionMessage() {
+		return exceptionCode.getMessage();
+	}
+
+	public HttpStatus getExceptionCode() {
+		return exceptionCode.getCode();
+	}
+}

--- a/src/main/java/com/barter/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/barter/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.barter.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.barter.exception.dto.ExceptionResDto;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(ExpectedException.class)
+	public ResponseEntity<ExceptionResDto> handleExpectedException(ExpectedException exception) {
+		ExceptionResDto response = ExceptionResDto.of(exception);
+		return ResponseEntity
+			.status(response.getCode())
+			.body(response);
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity<ExceptionResDto> handleUnExpectedException(RuntimeException exception) {
+		ExceptionResDto response = ExceptionResDto.builder()
+			.code(HttpStatus.INTERNAL_SERVER_ERROR)
+			.message(exception.getMessage())
+			.build();
+		return ResponseEntity
+			.status(response.getCode())
+			.body(response);
+	}
+}

--- a/src/main/java/com/barter/exception/customexceptions/AuthException.java
+++ b/src/main/java/com/barter/exception/customexceptions/AuthException.java
@@ -1,0 +1,10 @@
+package com.barter.exception.customexceptions;
+
+import com.barter.exception.ExpectedException;
+import com.barter.exception.enums.ExceptionCode;
+
+public class AuthException extends ExpectedException {
+	public AuthException(ExceptionCode exceptionCode) {
+		super(exceptionCode);
+	}
+}

--- a/src/main/java/com/barter/exception/customexceptions/MemberException.java
+++ b/src/main/java/com/barter/exception/customexceptions/MemberException.java
@@ -1,0 +1,10 @@
+package com.barter.exception.customexceptions;
+
+import com.barter.exception.ExpectedException;
+import com.barter.exception.enums.ExceptionCode;
+
+public class MemberException extends ExpectedException {
+	public MemberException(ExceptionCode exceptionCode) {
+		super(exceptionCode);
+	}
+}

--- a/src/main/java/com/barter/exception/dto/ExceptionResDto.java
+++ b/src/main/java/com/barter/exception/dto/ExceptionResDto.java
@@ -1,0 +1,28 @@
+package com.barter.exception.dto;
+
+import org.springframework.http.HttpStatus;
+
+import com.barter.exception.ExpectedException;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ExceptionResDto {
+
+	private final String message;
+	private final HttpStatus code;
+
+	@Builder
+	public ExceptionResDto(String message, HttpStatus code) {
+		this.message = message;
+		this.code = code;
+	}
+
+	public static ExceptionResDto of(ExpectedException exception) {
+		return ExceptionResDto.builder()
+			.message(exception.getExceptionMessage())
+			.code(exception.getExceptionCode())
+			.build();
+	}
+}

--- a/src/main/java/com/barter/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/barter/exception/enums/ExceptionCode.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ExceptionCode {
 	// 인증, 인가
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다.");
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다."),
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다."),
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일 입니다.");
 
 	private final HttpStatus code;
 	private final String message;

--- a/src/main/java/com/barter/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/barter/exception/enums/ExceptionCode.java
@@ -1,0 +1,16 @@
+package com.barter.exception.enums;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+	// 인증, 인가
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 멤버입니다.");
+
+	private final HttpStatus code;
+	private final String message;
+}


### PR DESCRIPTION
## 개요

- GlobalExceptionHandler 구현 후 예측 가능한 예외와 예측하지 못한 예외를 구분해서 반환하도록 구현
- 예측가능한 예외는 전부 ExpectedException을 상속받아주기만 하면 됨
- 적용 예시로 AuthException, MemberException 구현 했음
- 사용하지 않게된 custom exception 제거

    Resolves: #240 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제