### PR TITLE
[REFACTOR] 물품 삭제(등록, 제안) - 신규 상태 적용

### DIFF
--- a/src/main/java/com/barter/domain/product/entity/RegisteredProduct.java
+++ b/src/main/java/com/barter/domain/product/entity/RegisteredProduct.java
@@ -105,8 +105,8 @@ public class RegisteredProduct extends BaseTimeStampEntity {
 	}
 
 	public void checkPossibleDelete() {
-		if (this.status != RegisteredStatus.PENDING) {
-			throw new IllegalArgumentException("PENDING 상태인 경우에만 등록 물품을 삭제할 수 있습니다.");
+		if (this.status != RegisteredStatus.PENDING && this.status != RegisteredStatus.COMPLETED) {
+			throw new IllegalArgumentException("PENDING 또는 COMPLETED 상태인 경우에만 등록 물품을 삭제할 수 있습니다.");
 		}
 	}
 

--- a/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
+++ b/src/main/java/com/barter/domain/product/entity/SuggestedProduct.java
@@ -113,8 +113,8 @@ public class SuggestedProduct extends BaseTimeStampEntity {
 	}
 
 	public void checkPossibleDelete() {
-		if (this.status != SuggestedStatus.PENDING) {
-			throw new IllegalArgumentException("PENDING 상태인 경우에만 제안 물품을 삭제할 수 있습니다.");
+		if (this.status != SuggestedStatus.PENDING && this.status != SuggestedStatus.COMPLETED) {
+			throw new IllegalArgumentException("PENDING 또는 COMPLETED 상태인 경우에만 제안 물품을 삭제할 수 있습니다.");
 		}
 	}
 

--- a/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
+++ b/src/test/java/com/barter/domain/product/RegisteredProductServiceTest.java
@@ -505,8 +505,8 @@ public class RegisteredProductServiceTest {
 	}
 
 	@Test
-	@DisplayName("등록 물품 삭제 - 성공 테스트")
-	void deleteRegisteredProductTest_Success() {
+	@DisplayName("등록 물품 삭제 - 성공 테스트1")
+	void deleteRegisteredProductTest_Success1() {
 		//given
 		Long registeredProductId = 1L;
 		Long verifiedMemberId = 1L;
@@ -514,6 +514,31 @@ public class RegisteredProductServiceTest {
 		RegisteredProduct testProduct = RegisteredProduct.builder()
 			.id(registeredProductId)
 			.status(RegisteredStatus.PENDING)
+			.images(List.of("image1", "image2"))
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+		registeredProductRepository.save(testProduct);
+
+		when(registeredProductRepository.findById(registeredProductId))
+			.thenReturn(Optional.of(testProduct));
+
+		//when
+		registeredProductService.deleteRegisteredProduct(registeredProductId, verifiedMemberId);
+
+		//then
+		assertThat(registeredProductRepository.count()).isEqualTo(0L);
+	}
+
+	@Test
+	@DisplayName("등록 물품 삭제 - 성공 테스트2")
+	void deleteRegisteredProductTest_Success2() {
+		//given
+		Long registeredProductId = 1L;
+		Long verifiedMemberId = 1L;
+
+		RegisteredProduct testProduct = RegisteredProduct.builder()
+			.id(registeredProductId)
+			.status(RegisteredStatus.COMPLETED)
 			.images(List.of("image1", "image2"))
 			.member(Member.builder().id(verifiedMemberId).build())
 			.build();

--- a/src/test/java/com/barter/domain/product/SuggestedProductServiceTest.java
+++ b/src/test/java/com/barter/domain/product/SuggestedProductServiceTest.java
@@ -7,8 +7,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,23 +16,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PagedModel;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.barter.common.s3.S3Service;
 import com.barter.domain.member.entity.Member;
 import com.barter.domain.product.dto.request.CreateSuggestedProductReqDto;
+import com.barter.domain.product.dto.request.UpdateSuggestedProductInfoReqDto;
+import com.barter.domain.product.dto.request.UpdateSuggestedProductStatusReqDto;
 import com.barter.domain.product.dto.response.CreateSuggestedProductResDto;
 import com.barter.domain.product.dto.response.FindSuggestedProductResDto;
-import com.barter.domain.product.dto.request.UpdateSuggestedProductInfoReqDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductInfoResDto;
-import com.barter.domain.product.dto.request.UpdateSuggestedProductStatusReqDto;
 import com.barter.domain.product.dto.response.UpdateSuggestedProductStatusResDto;
 import com.barter.domain.product.entity.SuggestedProduct;
 import com.barter.domain.product.enums.SuggestedStatus;
@@ -507,8 +507,8 @@ public class SuggestedProductServiceTest {
 	}
 
 	@Test
-	@DisplayName("제안 물품 삭제 - 성공 테스트")
-	void deleteSuggestedProductTest_Success() {
+	@DisplayName("제안 물품 삭제 - 성공 테스트1")
+	void deleteSuggestedProductTest_Success1() {
 		//given
 		Long suggestedProductId = 1L;
 		Long verifiedMemberId = 1L;
@@ -516,6 +516,31 @@ public class SuggestedProductServiceTest {
 		SuggestedProduct testProduct = SuggestedProduct.builder()
 			.id(suggestedProductId)
 			.status(SuggestedStatus.PENDING)
+			.images(List.of("image1", "image2"))
+			.member(Member.builder().id(verifiedMemberId).build())
+			.build();
+		suggestedProductRepository.save(testProduct);
+
+		when(suggestedProductRepository.findById(suggestedProductId))
+			.thenReturn(Optional.of(testProduct));
+
+		//when
+		suggestedProductService.deleteSuggestedProduct(suggestedProductId, verifiedMemberId);
+
+		//then
+		assertThat(suggestedProductRepository.count()).isEqualTo(0);
+	}
+
+	@Test
+	@DisplayName("제안 물품 삭제 - 성공 테스트2")
+	void deleteSuggestedProductTest_Success2() {
+		//given
+		Long suggestedProductId = 1L;
+		Long verifiedMemberId = 1L;
+
+		SuggestedProduct testProduct = SuggestedProduct.builder()
+			.id(suggestedProductId)
+			.status(SuggestedStatus.COMPLETED)
 			.images(List.of("image1", "image2"))
 			.member(Member.builder().id(verifiedMemberId).build())
 			.build();


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
`등록 물품 상태` 와 `제안 물품 상태` 에 `COMPLETED(완료됨)` 가 추가되어 물품 삭제시 기존의 `PENDING` 과 함께 `COMPLETED` 도 삭제 가능한 상태로 추가하는 리팩토링을 진행했습니다.
- 기존과 같이 `REGISTERING(or SUGGESTING), ACCEPTED` 는 삭제가 불가능한 상태입니다.
- 물품 상태가 `COMPLETED` 일 때 삭제가 성공하는 테스트 또한 각각 작성했습니다.

Resolves: #268 

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제