### PR TITLE
FEAT: 즉시 교환 - 제안 조회 기능 구현

### DIFF
--- a/src/main/java/com/barter/domain/trade/immediatetrade/controller/ImmediateTradeController.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/controller/ImmediateTradeController.java
@@ -1,5 +1,7 @@
 package com.barter.domain.trade.immediatetrade.controller;
 
+import java.util.List;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
@@ -17,9 +19,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.barter.domain.auth.dto.VerifiedMember;
 import com.barter.domain.trade.immediatetrade.dto.request.CreateImmediateTradeReqDto;
 import com.barter.domain.trade.immediatetrade.dto.request.CreateTradeSuggestProductReqDto;
+import com.barter.domain.trade.immediatetrade.dto.request.FindSuggestForImmediateTradeReqDto;
 import com.barter.domain.trade.immediatetrade.dto.request.UpdateImmediateTradeReqDto;
 import com.barter.domain.trade.immediatetrade.dto.request.UpdateStatusReqDto;
 import com.barter.domain.trade.immediatetrade.dto.response.FindImmediateTradeResDto;
+import com.barter.domain.trade.immediatetrade.dto.response.FindSuggestForImmediateTradeResDto;
 import com.barter.domain.trade.immediatetrade.service.ImmediateTradeService;
 
 import jakarta.validation.Valid;
@@ -80,6 +84,14 @@ public class ImmediateTradeController {
 	public ResponseEntity<FindImmediateTradeResDto> updateStatus(@PathVariable Long tradeId,
 		@Valid @RequestBody UpdateStatusReqDto reqDto, VerifiedMember member) {
 		return new ResponseEntity<>(immediateTradeService.updateStatusCompleted(tradeId, reqDto, member),
+			HttpStatus.OK);
+	}
+
+	@GetMapping("/suggest")
+	public ResponseEntity<List<FindSuggestForImmediateTradeResDto>> findSuggestForImmediateTrade(
+		@RequestBody FindSuggestForImmediateTradeReqDto reqDto, VerifiedMember member) {
+		Long tradeId = reqDto.getTradeId();
+		return new ResponseEntity<>(immediateTradeService.findSuggestForImmediateTrade(tradeId, member),
 			HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/barter/domain/trade/immediatetrade/dto/request/FindSuggestForImmediateTradeReqDto.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/dto/request/FindSuggestForImmediateTradeReqDto.java
@@ -1,0 +1,8 @@
+package com.barter.domain.trade.immediatetrade.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FindSuggestForImmediateTradeReqDto {
+	Long tradeId;
+}

--- a/src/main/java/com/barter/domain/trade/immediatetrade/dto/response/FindSuggestForImmediateTradeResDto.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/dto/response/FindSuggestForImmediateTradeResDto.java
@@ -1,0 +1,38 @@
+package com.barter.domain.trade.immediatetrade.dto.response;
+
+import java.util.List;
+
+import com.barter.domain.product.entity.SuggestedProduct;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class FindSuggestForImmediateTradeResDto {
+
+	Long suggestedProductId;
+	String suggestedProductName;
+	String description;
+	List<String> images;
+	Long memberId;
+
+	@Builder
+	public FindSuggestForImmediateTradeResDto(Long suggestedProductId, String suggestedProductName, String description,
+		List<String> images, Long memberId) {
+		this.suggestedProductId = suggestedProductId;
+		this.suggestedProductName = suggestedProductName;
+		this.description = description;
+		this.images = images;
+		this.memberId = memberId;
+	}
+
+	public static FindSuggestForImmediateTradeResDto from(SuggestedProduct suggestedProduct) {
+		return FindSuggestForImmediateTradeResDto.builder()
+			.suggestedProductId(suggestedProduct.getId())
+			.suggestedProductName(suggestedProduct.getName())
+			.description(suggestedProduct.getDescription())
+			.images(suggestedProduct.getImages())
+			.memberId(suggestedProduct.getMember().getId())
+			.build();
+	}
+}

--- a/src/main/java/com/barter/domain/trade/immediatetrade/service/ImmediateTradeService.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/service/ImmediateTradeService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,7 @@ import com.barter.domain.trade.immediatetrade.dto.request.CreateTradeSuggestProd
 import com.barter.domain.trade.immediatetrade.dto.request.UpdateImmediateTradeReqDto;
 import com.barter.domain.trade.immediatetrade.dto.request.UpdateStatusReqDto;
 import com.barter.domain.trade.immediatetrade.dto.response.FindImmediateTradeResDto;
+import com.barter.domain.trade.immediatetrade.dto.response.FindSuggestForImmediateTradeResDto;
 import com.barter.domain.trade.immediatetrade.entity.ImmediateTrade;
 import com.barter.domain.trade.immediatetrade.repository.ImmediateTradeRepository;
 
@@ -206,13 +208,14 @@ public class ImmediateTradeService {
 		immediateTrade.changeStatusCompleted();
 		immediateTrade.getProduct().changeStatusCompleted();
 
-		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(tradeId, TradeType.IMMEDIATE);
+		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(tradeId,
+			TradeType.IMMEDIATE);
 		for (TradeProduct tradeProduct : tradeProducts) {
-			if(tradeProduct.getSuggestedProduct().getStatus() == SuggestedStatus.ACCEPTED) {
+			if (tradeProduct.getSuggestedProduct().getStatus() == SuggestedStatus.ACCEPTED) {
 				tradeProduct.getSuggestedProduct().changeStatusCompleted();
 			}
 
-			if(tradeProduct.getSuggestedProduct().getStatus() == SuggestedStatus.SUGGESTING) {
+			if (tradeProduct.getSuggestedProduct().getStatus() == SuggestedStatus.SUGGESTING) {
 				tradeProduct.getSuggestedProduct().changeStatusPending();
 				tradeProductRepository.delete(tradeProduct);
 			}
@@ -220,5 +223,27 @@ public class ImmediateTradeService {
 
 		ImmediateTrade updatedTrade = immediateTradeRepository.save(immediateTrade);
 		return FindImmediateTradeResDto.from(updatedTrade);
+	}
+
+	public List<FindSuggestForImmediateTradeResDto> findSuggestForImmediateTrade(
+		Long tradeId, VerifiedMember member) {
+
+		ImmediateTrade immediateTrade = immediateTradeRepository.findById(tradeId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 교환을 찾을 수 없습니다."));
+
+		immediateTrade.validateAuthority(member.getId());
+
+		List<TradeProduct> tradeProducts = tradeProductRepository.findAllByTradeIdAndTradeType(
+			tradeId, TradeType.IMMEDIATE);
+
+		List<FindSuggestForImmediateTradeResDto> resDtos = new ArrayList<>();
+
+		for (TradeProduct tp : tradeProducts) {
+			SuggestedProduct suggestedProduct = suggestedProductRepository.findById(tp.getSuggestedProduct().getId())
+				.orElseThrow(() -> new IllegalArgumentException("제안 물품을 찾을 수 없습니다"));
+
+			resDtos.add(FindSuggestForImmediateTradeResDto.from(suggestedProduct));
+		}
+		return resDtos;
 	}
 }


### PR DESCRIPTION
#275

## 개요

- 교환 등록자는 본인의 교환에 온 제안만 조회 가능하도록 구현했습니다.
- 다건 조회만 구현, 제안 단건 조회는 제안 물품 조회와 같다고 생각했습니다.

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제