### PR TITLE
chore: 주석 제거 및 제안 수락 취소 성공 시 문구 수정

### DIFF
--- a/src/main/java/com/barter/domain/trade/immediatetrade/controller/ImmediateTradeController.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/controller/ImmediateTradeController.java
@@ -88,11 +88,11 @@ public class ImmediateTradeController {
 			HttpStatus.OK);
 	}
 
-	// todo: 추후 제안 다건 조회되도록 변경
 	@PatchMapping("/cancelling-acceptance")
-	public String cancelAcceptanceOfSuggest(@RequestBody CancelAcceptanceReqDto reqDto, VerifiedMember verifiedMember) {
+	public ResponseEntity<String> cancelAcceptanceOfSuggest(@RequestBody CancelAcceptanceReqDto reqDto, VerifiedMember verifiedMember) {
 		Long tradeId = reqDto.getTradeId();
-		return immediateTradeService.cancelAcceptanceOfSuggest(tradeId, verifiedMember);
+		return new ResponseEntity<>(immediateTradeService.cancelAcceptanceOfSuggest(tradeId, verifiedMember),
+			HttpStatus.ACCEPTED);
 	}
 
 	@GetMapping("/suggest")

--- a/src/main/java/com/barter/domain/trade/immediatetrade/service/ImmediateTradeService.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/service/ImmediateTradeService.java
@@ -244,7 +244,7 @@ public class ImmediateTradeService {
 			tradeProductRepository.delete(tradeProduct);
 		}
 
-		return "추후 제안 다건 조회되도록 변경";
+		return "제안 수락 취소 완료";
 	}
 	public List<FindSuggestForImmediateTradeResDto> findSuggestForImmediateTrade(
 		Long tradeId, VerifiedMember member) {


### PR DESCRIPTION
#274

## 개요

- 원안 : 제안 수락 취소 시 해당 교환에 대한 제안 목록을 다시 보여주도록 하려 했으나, 프론트에서 가능할 것으로 판단.
- 수정안: "제안 수락 취소 완료" 반환.

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제