### PR TITLE
[FEAT] 알림 - 기간 교환 마감 이벤트에 적용

### DIFF
--- a/src/main/java/com/barter/domain/notification/enums/EventKind.java
+++ b/src/main/java/com/barter/domain/notification/enums/EventKind.java
@@ -17,8 +17,9 @@ public enum EventKind {
 	PERIOD_TRADE_SUGGEST("기간 교환, 제안 신청", " 교환에 제안이 들어왔어요!"),
 	PERIOD_TRADE_SUGGEST_ACCEPT("기간 교환, 제안 수락", " 교환에 신청한 제안이 수락되었어요!"),
 	PERIOD_TRADE_SUGGEST_DENY("기간 교환, 제안 거절", " 교환에 신청한 제안이 거절되었어요."),
-	PERIOD_TRADE_CLOSE("기간 교환, 제안 수락", " 교환이 종료되었습니다."),
-	PERIOD_TRADE_COMPLETE("기간 교환, 제안 수락", " 교환을 마쳤습니다!"),
+	PERIOD_TRADE_CLOSE("기간 교환, 교환 종료", " 교환이 종료되었습니다."),
+	PERIOD_TRADE_COMPLETE("기간 교환, 교환 완료", " 교환을 마쳤습니다!"),
+	PERIOD_TRADE_PERIOD_EXPIRES("기간 교환, 교환 마감", " 교환이 마감되었습니다."),
 
 	DONATION_TRADE_SUGGEST("나눔 교환, 나눔 신청", " 을(를) 누군가 나눔받았어요!"),
 


### PR DESCRIPTION
## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- `기간 교환 마감(기간이 지나서)` 시 발생하는 이벤트 정보를 아래와 같이 회원에게 실시간으로 전달하는 기능을 추가했습니다.
    - `교환 등록 회원` 은 자신의 교환이 마감되었다는 이벤트 정보를 전달 받습니다.
    - 해당 교환의 `제안 회원(들)` 은 신청한 제안이 거절되었다는 이벤트 정보를 전달 받습니다.

Resolves: #294 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제