### PR TITLE
FIX: 지연로딩으로 인해 맴버 객체를 가져오지 못하는 문제 해결

### DIFF
--- a/src/main/java/com/barter/domain/search/controller/SearchController.java
+++ b/src/main/java/com/barter/domain/search/controller/SearchController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.barter.domain.search.dto.SearchTradeResDto;
@@ -20,8 +21,11 @@ import lombok.RequiredArgsConstructor;
 public class SearchController {
 	private final SearchService searchService;
 
-	@GetMapping("/{word}")
-	public ResponseEntity<List<SearchTradeResDto>> findTrades(@PathVariable String word) {
+	@GetMapping("/trades")
+	public ResponseEntity<List<SearchTradeResDto>> findTrades(@RequestParam String word) {
+		if (word == null || word.isBlank()) {
+			throw new IllegalArgumentException("검색어는 필수입니다.");
+		}
 		return new ResponseEntity<>(searchService.searchKeywordAndFindTrades(word), HttpStatus.OK);
 	}
 

--- a/src/main/java/com/barter/domain/search/controller/SearchController.java
+++ b/src/main/java/com/barter/domain/search/controller/SearchController.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;

--- a/src/main/java/com/barter/domain/search/dto/ConvertProductDto.java
+++ b/src/main/java/com/barter/domain/search/dto/ConvertProductDto.java
@@ -1,0 +1,18 @@
+package com.barter.domain.search.dto;
+
+import java.util.List;
+
+import com.barter.domain.product.enums.RegisteredStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConvertProductDto {
+	private Long id;
+	private String name;
+	private String description;
+	private List<String> images;
+	private RegisteredStatus status;
+}

--- a/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
+++ b/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
@@ -1,6 +1,5 @@
 package com.barter.domain.search.dto;
 
-import com.barter.domain.search.service.SearchService;
 import com.barter.domain.trade.enums.TradeStatus;
 
 import lombok.Builder;
@@ -11,12 +10,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SearchTradeResDto {
 	private String title;
-	private SearchService.SimpleProductDto product; // RegisteredProduct에서 SimpleProductDto로 변경
+	private ConvertProductDto product;
 	private TradeStatus tradeStatus;
 	private int viewCount;
 
 	@Builder
-	public SearchTradeResDto(String title, SearchService.SimpleProductDto product, TradeStatus tradeStatus,
+	public SearchTradeResDto(String title, ConvertProductDto product, TradeStatus tradeStatus,
 		int viewCount) {
 		this.title = title;
 		this.product = product;

--- a/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
+++ b/src/main/java/com/barter/domain/search/dto/SearchTradeResDto.java
@@ -1,6 +1,6 @@
 package com.barter.domain.search.dto;
 
-import com.barter.domain.product.entity.RegisteredProduct;
+import com.barter.domain.search.service.SearchService;
 import com.barter.domain.trade.enums.TradeStatus;
 
 import lombok.Builder;
@@ -10,18 +10,17 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class SearchTradeResDto {
-
 	private String title;
-	private RegisteredProduct product;
+	private SearchService.SimpleProductDto product; // RegisteredProduct에서 SimpleProductDto로 변경
 	private TradeStatus tradeStatus;
 	private int viewCount;
 
 	@Builder
-	public SearchTradeResDto(String title, RegisteredProduct product, TradeStatus tradeStatus, int viewCount) {
+	public SearchTradeResDto(String title, SearchService.SimpleProductDto product, TradeStatus tradeStatus,
+		int viewCount) {
 		this.title = title;
 		this.product = product;
 		this.tradeStatus = tradeStatus;
 		this.viewCount = viewCount;
 	}
-
 }

--- a/src/main/java/com/barter/domain/search/service/SearchService.java
+++ b/src/main/java/com/barter/domain/search/service/SearchService.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.barter.domain.product.entity.RegisteredProduct;
-import com.barter.domain.product.enums.RegisteredStatus;
 import com.barter.domain.search.dto.SearchTradeResDto;
+import com.barter.domain.search.dto.ConvertProductDto;
 import com.barter.domain.search.entity.SearchHistory;
 import com.barter.domain.search.entity.SearchKeyword;
 import com.barter.domain.search.repository.SearchHistoryRepository;
@@ -22,8 +22,6 @@ import com.barter.domain.trade.immediatetrade.repository.ImmediateTradeRepositor
 import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
 import com.barter.domain.trade.periodtrade.repository.PeriodTradeRepository;
 
-import lombok.Builder;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -131,17 +129,9 @@ public class SearchService {
 				.build())
 			.toList();
 	}
-	@Getter
-	@Builder
-	public static class SimpleProductDto {
-		private Long id;
-		private String name;
-		private String description;
-		private List<String> images;
-		private RegisteredStatus status;
-	}
-	private SimpleProductDto createSimpleProductDto(RegisteredProduct product) {
-		return SimpleProductDto.builder()
+
+	private ConvertProductDto createSimpleProductDto(RegisteredProduct product) {
+		return ConvertProductDto.builder()
 			.id(product.getId())
 			.name(product.getName())
 			.description(product.getDescription())

--- a/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.barter.domain.trade.donationtrade.entity.DonationTrade;
 
@@ -17,5 +18,8 @@ public interface DonationTradeRepository extends JpaRepository<DonationTrade, Lo
 	@Query("select d from DonationTrade d where d.id = :tradeId")
 	Optional<DonationTrade> findByIdForUpdate(Long tradeId);
 
-	List<DonationTrade> findByTitleOrDescriptionContaining(String title, String description);
+	@Query("SELECT dt FROM DonationTrade dt " +
+		"JOIN FETCH dt.product p " +
+		"WHERE dt.title LIKE %:keyword% OR dt.description LIKE %:keyword%")
+	List<DonationTrade> findDonationTradesWithProduct(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/barter/domain/trade/immediatetrade/repository/ImmediateTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/immediatetrade/repository/ImmediateTradeRepository.java
@@ -3,10 +3,17 @@ package com.barter.domain.trade.immediatetrade.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.barter.domain.trade.donationtrade.entity.DonationTrade;
 import com.barter.domain.trade.immediatetrade.entity.ImmediateTrade;
 
 public interface ImmediateTradeRepository extends JpaRepository<ImmediateTrade, Long> {
 
-	List<ImmediateTrade> findByTitleOrDescriptionContaining(String title, String description);
+
+	@Query("SELECT it FROM ImmediateTrade it " +
+		"JOIN FETCH it.product p " +
+		"WHERE it.title LIKE %:keyword% OR it.description LIKE %:keyword%")
+	List<ImmediateTrade> findImmediateTradesWithProduct(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/barter/domain/trade/periodtrade/repository/PeriodTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/periodtrade/repository/PeriodTradeRepository.java
@@ -3,10 +3,16 @@ package com.barter.domain.trade.periodtrade.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.barter.domain.trade.immediatetrade.entity.ImmediateTrade;
 import com.barter.domain.trade.periodtrade.entity.PeriodTrade;
 
 public interface PeriodTradeRepository extends JpaRepository<PeriodTrade, Long> {
 
-	List<PeriodTrade> findByTitleOrDescriptionContaining(String title, String description);
+	@Query("SELECT pt FROM PeriodTrade pt " +
+		"JOIN FETCH pt.registeredProduct p " +
+		"WHERE pt.title LIKE %:keyword% OR pt.description LIKE %:keyword%")
+	List<PeriodTrade> findPeriodTradesWithProduct(@Param("keyword") String keyword);
 }

--- a/src/test/java/com/barter/domain/search/SearchServiceUnitTest.java
+++ b/src/test/java/com/barter/domain/search/SearchServiceUnitTest.java
@@ -95,7 +95,7 @@ public class SearchServiceUnitTest {
 
 		when(searchKeywordRepository.findByWord(word)).thenReturn(Optional.of(existingKeyword));
 
-		when(donationTradeRepository.findByTitleOrDescriptionContaining(word, word)).thenReturn(donationTrades);
+		// when(donationTradeRepository.findByTitleOrDescriptionContaining(word, word)).thenReturn(donationTrades)
 		when(periodTradeRepository.findByTitleOrDescriptionContaining(word, word)).thenReturn(periodTrades);
 
 		List<SearchTradeResDto> result = searchService.searchKeywordAndFindTrades(word);


### PR DESCRIPTION
#304
## 개요
- 지연로딩으로 인해 맴버 객체를 가져오지 못하는 문제 해결했습니다.
- 맴버 객체가 필요 없게끔 만들었습니다.
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

---
## 상세 설명

이전에는 교환에서 ResDto로 변환할 때

```
private List<SearchTradeResDto> mapImmediateTradesToSearchTradeRes(List<ImmediateTrade> trades) {
return trades.stream()
	.map(trade -> SearchTradeResDto.builder()
		.title(trade.getTitle())
		.product(trade.getProduct())
		.tradeStatus(trade.getStatus())
		.viewCount(trade.getViewCount())
		.build())
	.toList();
}
```
`.product(trade.getProduct())`가 있어서 문제 발생합니다. 

1. 여기서 RegisteredProduct 엔티티 전체를 그대로 SearchTradeResDto에 담습니다. 
2. RegisteredProduct 안에는 @ManyToOne(fetch = FetchType.LAZY) private Member member가 있습니다. 
3. JSON 변환 시점에서 Jackson이 RegisteredProduct의 모든 필드를 직렬화하려고 시도합니다. 
4. Member 필드에 접근하려고 할 때, 이미 트랜잭션이 종료되어 Session이 닫혀있어서 에러가 발생합니다.

---

수정 후 

`.product(createSimpleProductDto(trade.getProduct())) // DTO로 변환`

- RegisteredProduct에서 필요한 데이터만 뽑아서 새로운 DTO 객체를 만듭니다.
- SimpleProductDto는 Member 필드가 없습니다. 따라서 에러가 발생하지 않습니다.
- JSON 변환 시점에서 Member에 접근할 일이 없으므로 에러가 발생하지 않습니다.



<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제