### PR TITLE
 refactor : 나눔교환 제안 시 동시성 제어 분산락 사용하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.17.4'
     // redis LocalDatetime Serialize-Deserialize
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
 
@@ -75,6 +76,7 @@ dependencies {
     implementation "com.querydsl:querydsl-collections"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 
 }
 

--- a/src/main/java/com/barter/config/RedissonConfig.java
+++ b/src/main/java/com/barter/config/RedissonConfig.java
@@ -1,0 +1,29 @@
+package com.barter.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	private static final String REDISSON_HOST_PREFIX = "redis://";
+
+	@Bean
+	public RedissonClient redissonClient() {
+		RedissonClient redisson;
+		Config config = new Config();
+		config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+		redisson = Redisson.create(config);
+		return redisson;
+	}
+}

--- a/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
@@ -1,22 +1,14 @@
 package com.barter.domain.trade.donationtrade.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.barter.domain.trade.donationtrade.entity.DonationTrade;
 
-import jakarta.persistence.LockModeType;
-
 public interface DonationTradeRepository extends JpaRepository<DonationTrade, Long> {
-
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("select d from DonationTrade d where d.id = :tradeId")
-	Optional<DonationTrade> findByIdForUpdate(Long tradeId);
 
 	@Query("SELECT dt FROM DonationTrade dt " +
 		"JOIN FETCH dt.product p " +

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.barter.domain.auth.dto.VerifiedMember;
@@ -103,14 +104,14 @@ public class DonationTradeService {
 		donationTradeRepository.delete(donationTrade);
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public SuggestDonationTradeResDto suggestDonationTrade(VerifiedMember verifiedMember, Long tradeId) {
 		if (donationProductMemberRepository.existsByMemberIdAndDonationTradeId(verifiedMember.getId(), tradeId)) {
 			throw new IllegalStateException("이미 요청한 유저입니다.");
 		}
 		Member requestMember = memberRepository.findById(verifiedMember.getId())
 			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-		DonationTrade donationTrade = donationTradeRepository.findByIdForUpdate(tradeId)
+		DonationTrade donationTrade = donationTradeRepository.findById(tradeId)
 			.orElseThrow(() -> new DonationTradeException(NOT_FOUND_DONATION_TRADE));
 		if (donationTrade.isDonationCompleted()) {
 			return new SuggestDonationTradeResDto(DONATION_SUGGEST_FAIL_MESSAGE, DonationResult.FAIL);

--- a/src/main/java/com/barter/lock/RedissonLockService.java
+++ b/src/main/java/com/barter/lock/RedissonLockService.java
@@ -1,0 +1,30 @@
+package com.barter.lock;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedissonLockService {
+
+	private final RedissonClient redissonClient;
+
+	public <T> T process(String methodName, Long tradeId, int timeoutSeconds, Supplier<T> supplier) throws Throwable {
+		final RLock lock = redissonClient.getLock(String.format(methodName, tradeId));
+		try {
+			boolean available = lock.tryLock(timeoutSeconds, TimeUnit.SECONDS);
+			if (!available) {
+				throw new IllegalArgumentException("Lock 획득에 실패하였습니다.");
+			}
+			return supplier.get();
+		} finally {
+			lock.unlock();
+		}
+	}
+}

--- a/src/test/java/com/barter/domain/trade/donationtrade/service/DonationTradeServiceTest.java
+++ b/src/test/java/com/barter/domain/trade/donationtrade/service/DonationTradeServiceTest.java
@@ -362,7 +362,7 @@ class DonationTradeServiceTest {
 
 		when(donationProductMemberRepository.existsByMemberIdAndDonationTradeId(1L, 100L)).thenReturn(false);
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-		when(donationTradeRepository.findByIdForUpdate(tradeId)).thenReturn(Optional.empty());
+		when(donationTradeRepository.findById(tradeId)).thenReturn(Optional.empty());
 
 		// when && then
 		assertThatThrownBy(() -> donationTradeService.suggestDonationTrade(verifiedMember, tradeId))
@@ -381,7 +381,7 @@ class DonationTradeServiceTest {
 
 		when(donationProductMemberRepository.existsByMemberIdAndDonationTradeId(1L, 100L)).thenReturn(false);
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-		when(donationTradeRepository.findByIdForUpdate(tradeId)).thenReturn(Optional.of(donationTrade));
+		when(donationTradeRepository.findById(tradeId)).thenReturn(Optional.of(donationTrade));
 		when(donationTrade.isDonationCompleted()).thenReturn(true);
 
 		// when
@@ -414,7 +414,7 @@ class DonationTradeServiceTest {
 
 		when(donationProductMemberRepository.existsByMemberIdAndDonationTradeId(1L, 100L)).thenReturn(false);
 		when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-		when(donationTradeRepository.findByIdForUpdate(tradeId)).thenReturn(Optional.of(donationTrade));
+		when(donationTradeRepository.findById(tradeId)).thenReturn(Optional.of(donationTrade));
 		when(donationTradeRepository.save(donationTrade)).thenReturn(donationTrade);
 		doNothing().when(notificationService).saveTradeNotification(any(), any(), any(), any(), any());
 


### PR DESCRIPTION
## 개요

- 기존 비관적 락은 동시성 제어 역할은 충분히 해냈지만, 데이터베이스 레코드 자체에 락을 걸어버려서 다른 api에서 조회 할 때에도 대기 시간이 발생할 가능성이 있었음.
- 분산락을 사용함으로써 임계영역에만 락을 걸어 해당 메서드 호출을 제어할 수 있도록 수정함.
- 또한, 트랜잭션 전파범위를 REQUIRE_NEW로 수정하여 기존 트랜잭션이 완전히 커밋된 이후에 락을 획득할 수 있도록 수정함.
- 기본적으로 제공하는 스프링 레디스는 Lecttuce를 제공하는데 Lecttuce는 스핀락 방식으로 redis서버에 부하가 많이 갈 것을 염려해 Redisson을 사용하여 Pub/Sub 구조로 락을 획득 및 해제할 수 있도록 구현하였음.

    Resolves: #370 

## PR 유형 

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제