### PR TITLE
refactor : 분삭락에서 비관적락으로 수정

### DIFF
--- a/src/main/java/com/barter/domain/trade/donationtrade/controller/DonationTradeController.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/controller/DonationTradeController.java
@@ -66,15 +66,10 @@ public class DonationTradeController {
 	public ResponseEntity<SuggestDonationTradeResDto> suggestDonationTrade(
 		VerifiedMember verifiedMember,
 		@PathVariable("tradeId") Long tradeId
-	) throws Throwable {
+	) {
 		return ResponseEntity
 			.status(HttpStatus.OK)
-			.body(
-				redissonLockService.process(
-					"donationTrades",
-					tradeId,
-					10,
-					() -> donationTradeService.suggestDonationTrade(verifiedMember, tradeId)));
+			.body(donationTradeService.suggestDonationTrade(verifiedMember, tradeId));
 	}
 
 	@PatchMapping("/{tradeId}")

--- a/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/repository/DonationTradeRepository.java
@@ -1,14 +1,24 @@
 package com.barter.domain.trade.donationtrade.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.barter.domain.trade.donationtrade.entity.DonationTrade;
 
+import jakarta.persistence.LockModeType;
+
 public interface DonationTradeRepository extends JpaRepository<DonationTrade, Long> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("select dt from DonationTrade dt "
+		+ "join fetch dt.product p "
+		+ "where dt.id = :tradeId")
+	Optional<DonationTrade> findByIdForUpdate(Long tradeId);
 
 	@Query("SELECT dt FROM DonationTrade dt " +
 		"JOIN FETCH dt.product p " +

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -103,7 +103,7 @@ public class DonationTradeService {
 		donationTradeRepository.delete(donationTrade);
 	}
 
-	@Transactional(timeout = 100)
+	@Transactional(timeout = 3)
 	public SuggestDonationTradeResDto suggestDonationTrade(VerifiedMember verifiedMember, Long tradeId) {
 		if (donationProductMemberRepository.existsByMemberIdAndDonationTradeId(verifiedMember.getId(), tradeId)) {
 			throw new IllegalStateException("이미 요청한 유저입니다.");

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -103,7 +103,7 @@ public class DonationTradeService {
 		donationTradeRepository.delete(donationTrade);
 	}
 
-	@Transactional
+	@Transactional(timeout = 100)
 	public SuggestDonationTradeResDto suggestDonationTrade(VerifiedMember verifiedMember, Long tradeId) {
 		if (donationProductMemberRepository.existsByMemberIdAndDonationTradeId(verifiedMember.getId(), tradeId)) {
 			throw new IllegalStateException("이미 요청한 유저입니다.");

--- a/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
+++ b/src/main/java/com/barter/domain/trade/donationtrade/service/DonationTradeService.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.barter.domain.auth.dto.VerifiedMember;
@@ -104,14 +103,14 @@ public class DonationTradeService {
 		donationTradeRepository.delete(donationTrade);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public SuggestDonationTradeResDto suggestDonationTrade(VerifiedMember verifiedMember, Long tradeId) {
 		if (donationProductMemberRepository.existsByMemberIdAndDonationTradeId(verifiedMember.getId(), tradeId)) {
 			throw new IllegalStateException("이미 요청한 유저입니다.");
 		}
 		Member requestMember = memberRepository.findById(verifiedMember.getId())
 			.orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-		DonationTrade donationTrade = donationTradeRepository.findById(tradeId)
+		DonationTrade donationTrade = donationTradeRepository.findByIdForUpdate(tradeId)
 			.orElseThrow(() -> new DonationTradeException(NOT_FOUND_DONATION_TRADE));
 		if (donationTrade.isDonationCompleted()) {
 			return new SuggestDonationTradeResDto(DONATION_SUGGEST_FAIL_MESSAGE, DonationResult.FAIL);


### PR DESCRIPTION
## 개요

- 비관적 락과 레디스 분삭락의 성능 테스트 결과 분삭락이 훨씬 느린것을 확인했음. 왜냐하면 데이터베이스 접근 전에 레디스 서버에 한 번씩 더 요청을 해야하기 때문
- 현재 확장 될지 알 수 없는 불확실한 미래를 위해 현재 프로젝트의 성능을 낮추는 것은 적절하지 못하다고 판단했기 떄문이다.
- 비관적 락의 문제점인 데드락은 Transactional timeout으로 해결할 수 있다고 생각했음

### 비관적 락 성능 테스트
- 기준 4분 30초 vuser 200
![스크린샷 2025-01-02 오후 5 03 15](https://github.com/user-attachments/assets/ad844c49-8b60-4879-9cfc-31958966e37c)

### 분산 락 성능 테스트 
- 기준 4분 30초 vuser 200
![스크린샷 2025-01-02 오후 8 03 30](https://github.com/user-attachments/assets/7e11d83a-428e-4961-9ca4-77bb380476ae)

    Resolves: #370 

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제